### PR TITLE
Endpoints listing unique values

### DIFF
--- a/ckanext/gdi_userportal/logic/action/fetcher/__init__.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/__init__.py
@@ -1,0 +1,7 @@
+from ckanext.gdi_userportal.logic.action.fetcher.dataset_fetcher import DatasetFetcher
+from ckanext.gdi_userportal.logic.action.fetcher.publisher_fetcher import (
+    PublisherFetcher,
+)
+from ckanext.gdi_userportal.logic.action.fetcher.theme_fetcher import ThemeFetcher
+
+__all__ = ["PublisherFetcher", "ThemeFetcher", "DatasetFetcher"]

--- a/ckanext/gdi_userportal/logic/action/fetcher/dataset_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/dataset_fetcher.py
@@ -1,0 +1,6 @@
+from ckanext.gdi_userportal.logic.action.fetcher.prop_fetcher import PropFetcher
+
+
+class DatasetFetcher(PropFetcher):
+    def _get_batched_prop_values(self, batched_datasets):
+        return [dataset["name"] for dataset in batched_datasets]

--- a/ckanext/gdi_userportal/logic/action/fetcher/prop_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/prop_fetcher.py
@@ -9,7 +9,7 @@ class PropFetcher(ABC):
         self._batch_size = batch_size
 
     def get_prop_list(self) -> dict[str, int | list[str]]:
-        nb_datasets = self._get_dataset_number()
+        nb_datasets = self._get_dataset_count()
         prop_values = []
 
         for i in range((nb_datasets // self._batch_size) + 1):
@@ -21,7 +21,7 @@ class PropFetcher(ABC):
 
         return {"count": len(prop_values), "values": prop_values}
 
-    def _get_dataset_number(self) -> int:
+    def _get_dataset_count(self) -> int:
         return toolkit.get_action("package_search")(
             self._context, {"include_private": False}
         )["count"]
@@ -34,5 +34,5 @@ class PropFetcher(ABC):
         return datasets
 
     @abstractmethod
-    def _get_batched_prop_values(self, batched_datasets) -> list[str]:
+    def _get_batched_prop_values(self, batched_datasets: list[dict]) -> list[str]:
         pass

--- a/ckanext/gdi_userportal/logic/action/fetcher/prop_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/prop_fetcher.py
@@ -19,7 +19,7 @@ class PropFetcher(ABC):
             batched_prop_values = self._get_batched_prop_values(batched_datasets)
             prop_values.extend(batched_prop_values)
 
-        return {"count": len(prop_values), "values": prop_values}
+        return {"count": len(prop_values), "results": prop_values}
 
     def _get_dataset_count(self) -> int:
         return toolkit.get_action("package_search")(

--- a/ckanext/gdi_userportal/logic/action/fetcher/prop_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/prop_fetcher.py
@@ -1,0 +1,38 @@
+from abc import ABC, abstractmethod
+
+from ckan.plugins import toolkit
+
+
+class PropFetcher(ABC):
+    def __init__(self, context, batch_size: int):
+        self._context = context
+        self._batch_size = batch_size
+
+    def get_prop_list(self) -> dict[str, int | list[str]]:
+        nb_datasets = self._get_dataset_number()
+        prop_values = []
+
+        for i in range((nb_datasets // self._batch_size) + 1):
+            batched_datasets = self._fetch_batched_datasets(
+                self._batch_size * i, self._batch_size
+            )
+            batched_prop_values = self._get_batched_prop_values(batched_datasets)
+            prop_values.extend(batched_prop_values)
+
+        return {"count": len(prop_values), "values": prop_values}
+
+    def _get_dataset_number(self) -> int:
+        return toolkit.get_action("package_search")(
+            self._context, {"include_private": False}
+        )["count"]
+
+    def _fetch_batched_datasets(self, start_row: int, nb_rows: int) -> list[dict]:
+        datasets = toolkit.get_action("package_search")(
+            self._context,
+            {"include_private": False, "start": start_row, "rows": nb_rows},
+        )["results"]
+        return datasets
+
+    @abstractmethod
+    def _get_batched_prop_values(self, batched_datasets) -> list[str]:
+        pass

--- a/ckanext/gdi_userportal/logic/action/fetcher/publisher_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/publisher_fetcher.py
@@ -1,0 +1,7 @@
+from ckanext.gdi_userportal.logic.action.fetcher.prop_fetcher import PropFetcher
+
+
+class PublisherFetcher(PropFetcher):
+    def _get_batched_prop_values(self, batched_datasets) -> list[str]:
+        publishers = set([dataset["publisher_name"] for dataset in batched_datasets])
+        return publishers

--- a/ckanext/gdi_userportal/logic/action/fetcher/theme_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/theme_fetcher.py
@@ -1,0 +1,21 @@
+import re
+from functools import reduce
+
+from ckanext.gdi_userportal.logic.action.fetcher.prop_fetcher import PropFetcher
+
+
+class ThemeFetcher(PropFetcher):
+    def _get_batched_prop_values(self, batched_datasets) -> list[str]:
+        themes = [
+            self._format_themes(dataset["theme"][0]) for dataset in batched_datasets
+        ]
+        themes = list(set(reduce(lambda themes1, themes2: themes1 + themes2, themes)))
+        return themes
+
+    @staticmethod
+    def _format_themes(themes: list[str]) -> list[str]:
+        if not themes:
+            return [""]
+
+        pattern = r'[\[\]" ]'
+        return re.sub(pattern, "", themes).split(",")

--- a/ckanext/gdi_userportal/logic/action/fetcher/theme_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/theme_fetcher.py
@@ -1,4 +1,3 @@
-import re
 from functools import reduce
 
 from ckanext.gdi_userportal.logic.action.fetcher.prop_fetcher import PropFetcher
@@ -6,16 +5,6 @@ from ckanext.gdi_userportal.logic.action.fetcher.prop_fetcher import PropFetcher
 
 class ThemeFetcher(PropFetcher):
     def _get_batched_prop_values(self, batched_datasets) -> list[str]:
-        themes = [
-            self._format_themes(dataset["theme"][0]) for dataset in batched_datasets
-        ]
+        themes = [dataset["theme"] for dataset in batched_datasets]
         themes = list(set(reduce(lambda themes1, themes2: themes1 + themes2, themes)))
         return themes
-
-    @staticmethod
-    def _format_themes(themes: list[str]) -> list[str]:
-        if not themes:
-            return [""]
-
-        pattern = r'[\[\]" ]'
-        return re.sub(pattern, "", themes).split(",")

--- a/ckanext/gdi_userportal/logic/action/get.py
+++ b/ckanext/gdi_userportal/logic/action/get.py
@@ -1,15 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from ckan.plugins import toolkit
 import logging
+
+from ckan.plugins import toolkit
+from ckanext.gdi_userportal.logic.action.fetcher import (
+    DatasetFetcher,
+    PublisherFetcher,
+    ThemeFetcher,
+)
 
 log = logging.getLogger(__name__)
 
 
 @toolkit.side_effect_free
 def scheming_package_show(context, data_dict):
-    '''
+    """
     Function made to be called on Dataplatform Portal. It provides an alternative for package_show,
     returning information in a format that is fitted to what the Dataplatform Portal needs
 
@@ -20,24 +26,48 @@ def scheming_package_show(context, data_dict):
     with a dictionary with 2 keys 'value' and 'labels' a dictionary which
     contains all the labels for that value in all languages.(default: `False`)
     :type include_labels: bool
-    '''
+    """
 
-    pkg_dict = toolkit.get_action('package_show')(context, data_dict)
-    schema = toolkit.get_action('scheming_dataset_schema_show')(context, data_dict)
-    dataset_fields = schema['dataset_fields']
+    pkg_dict = toolkit.get_action("package_show")(context, data_dict)
+    schema = toolkit.get_action("scheming_dataset_schema_show")(context, data_dict)
+    dataset_fields = schema["dataset_fields"]
 
     new_pkg_dict = {}
     fields_not_in_schema_that_should_be_visible = [
-        {"name": "metadata_created", "label": {"en": "Metadata Created", "nl": "Gecreëerd", "sv": "Metadata skapad"}},
-        {"name": "metadata_modified",
-         "label": {"en": "Metadata Modified", "nl": "Laatst gewijzigd", "sv": "Metadata modifierad"}},
-        {"name": "organization", "label": {"en": "Organization", "nl": "Organisatie", "sv": "Organization"}},
-        {"name": "license_title", "label": {"en": "License", "nl": "Licentie", "sv": "Licens"}},
+        {
+            "name": "metadata_created",
+            "label": {
+                "en": "Metadata Created",
+                "nl": "Gecreëerd",
+                "sv": "Metadata skapad",
+            },
+        },
+        {
+            "name": "metadata_modified",
+            "label": {
+                "en": "Metadata Modified",
+                "nl": "Laatst gewijzigd",
+                "sv": "Metadata modifierad",
+            },
+        },
+        {
+            "name": "organization",
+            "label": {"en": "Organization", "nl": "Organisatie", "sv": "Organization"},
+        },
+        {
+            "name": "license_title",
+            "label": {"en": "License", "nl": "Licentie", "sv": "Licens"},
+        },
     ]
-    fields_in_schema_that_should_not_be_visible = ["license_id", "notes", "owner_org", "title"]
+    fields_in_schema_that_should_not_be_visible = [
+        "license_id",
+        "notes",
+        "owner_org",
+        "title",
+    ]
 
     for field in dataset_fields:
-        field_name = field['field_name']
+        field_name = field["field_name"]
         try:
             value = pkg_dict[field_name]
         except KeyError:
@@ -47,41 +77,88 @@ def scheming_package_show(context, data_dict):
         # Default visibility is True
         # If display_snippet = hidden.html or null OR part of the exceptions list then visible false
 
-        if ('display_snippet' in field and field['display_snippet'] in [None, 'hidden.html']) \
-                or field_name in fields_in_schema_that_should_not_be_visible:
+        if (
+            "display_snippet" in field
+            and field["display_snippet"] in [None, "hidden.html"]
+        ) or field_name in fields_in_schema_that_should_not_be_visible:
             visible = False
         else:
             visible = True
 
-        field_label = field.get('label', None)
+        field_label = field.get("label", None)
         choices = toolkit.h.scheming_field_choices(field)
 
         if choices is None:
-            new_pkg_dict[field_name] = {"value": value, "value_label": None,
-                                        "field_label": field_label, "visible": visible}
+            new_pkg_dict[field_name] = {
+                "value": value,
+                "value_label": None,
+                "field_label": field_label,
+                "visible": visible,
+            }
             del pkg_dict[field_name]
             continue
 
         for choice in choices:
-            if choice['value'] == value:
-                new_pkg_dict[field_name] = {"value": value, "value_label": choice['label'],
-                                            "field_label": field_label, "visible": visible}
+            if choice["value"] == value:
+                new_pkg_dict[field_name] = {
+                    "value": value,
+                    "value_label": choice["label"],
+                    "field_label": field_label,
+                    "visible": visible,
+                }
                 del pkg_dict[field_name]
                 break
 
     for fieldname in pkg_dict:
         field_label = None
-        visible = any(fieldname in field_dict['name'] for field_dict in fields_not_in_schema_that_should_be_visible)
+        visible = any(
+            fieldname in field_dict["name"]
+            for field_dict in fields_not_in_schema_that_should_be_visible
+        )
         if visible:
             for field_dict in fields_not_in_schema_that_should_be_visible:
-                if field_dict['name'] == fieldname:
-                    field_label = field_dict['label']
+                if field_dict["name"] == fieldname:
+                    field_label = field_dict["label"]
 
-        default_field_dict = {"value": pkg_dict[fieldname],
-                              "value_label": None,
-                              "field_label": field_label,
-                              'visible': visible
-                              }
+        default_field_dict = {
+            "value": pkg_dict[fieldname],
+            "value_label": None,
+            "field_label": field_label,
+            "visible": visible,
+        }
         new_pkg_dict[fieldname] = default_field_dict
 
     return new_pkg_dict
+
+
+@toolkit.side_effect_free
+def get_keyword_list(context, data_dict) -> dict[str, int | list[str]]:
+    keywords = list(set(toolkit.get_action("tag_list")(context, data_dict)))
+    return {"count": len(keywords), "values": keywords}
+
+
+@toolkit.side_effect_free
+def get_catalogue_list(context, data_dict) -> dict[str, int | list[str]]:
+    organizations = list(
+        set(
+            toolkit.get_action("organization_list")(
+                context, {"permission_list": "read"}
+            )
+        )
+    )
+    return {"count": len(organizations), "values": organizations}
+
+
+@toolkit.side_effect_free
+def get_publisher_list(context, data_dict) -> dict[str, int | list[str]]:
+    return PublisherFetcher(context, batch_size=256).get_prop_list()
+
+
+@toolkit.side_effect_free
+def get_theme_list(context, data_dict) -> dict[str, int | list[str]]:
+    return ThemeFetcher(context, batch_size=256).get_prop_list()
+
+
+@toolkit.side_effect_free
+def get_dataset_list(context, data_dict) -> dict[str, int | list[str]]:
+    return DatasetFetcher(context, batch_size=256).get_prop_list()

--- a/ckanext/gdi_userportal/logic/action/get.py
+++ b/ckanext/gdi_userportal/logic/action/get.py
@@ -129,7 +129,7 @@ def scheming_package_show(context, data_dict):
 @toolkit.side_effect_free
 def get_keyword_list(context, data_dict) -> dict[str, int | list[str]]:
     keywords = list(set(toolkit.get_action("tag_list")(context, data_dict)))
-    return {"count": len(keywords), "values": keywords}
+    return {"count": len(keywords), "results": keywords}
 
 
 @toolkit.side_effect_free
@@ -141,7 +141,7 @@ def get_catalogue_list(context, data_dict) -> dict[str, int | list[str]]:
             )
         )
     )
-    return {"count": len(organizations), "values": organizations}
+    return {"count": len(organizations), "results": organizations}
 
 
 @toolkit.side_effect_free

--- a/ckanext/gdi_userportal/plugin.py
+++ b/ckanext/gdi_userportal/plugin.py
@@ -1,7 +1,14 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
-import ckanext.gdi_userportal.logic.auth.get as auth_get
-import ckanext.gdi_userportal.logic.action.get as action_get
+from ckanext.gdi_userportal.logic.action.get import (
+    get_catalogue_list,
+    get_dataset_list,
+    get_keyword_list,
+    get_publisher_list,
+    get_theme_list,
+    scheming_package_show,
+)
+from ckanext.gdi_userportal.logic.auth.get import config_option_show
 
 
 class GdiUserPortalPlugin(plugins.SingletonPlugin):
@@ -9,21 +16,22 @@ class GdiUserPortalPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IFacets, inherit=True)
     plugins.implements(plugins.IAuthFunctions)
     plugins.implements(plugins.IActions)
-    
+
     # IConfigurer
 
     def update_config(self, config_):
         toolkit.add_template_directory(config_, "templates")
         toolkit.add_public_directory(config_, "public")
         toolkit.add_resource("assets", "ckanext-gdi-userportal")
-    
+
         # IConfigurer
+
     def update_config_schema(self, schema):
-        ignore_missing = toolkit.get_validator('ignore_missing')
-        unicode_safe = toolkit.get_validator('unicode_safe')
-        schema.update({
-            'ckanext.gdi_userportal.intro_text': [ignore_missing, unicode_safe]
-        })
+        ignore_missing = toolkit.get_validator("ignore_missing")
+        unicode_safe = toolkit.get_validator("unicode_safe")
+        schema.update(
+            {"ckanext.gdi_userportal.intro_text": [ignore_missing, unicode_safe]}
+        )
         return schema
 
     # IFacets
@@ -42,12 +50,16 @@ class GdiUserPortalPlugin(plugins.SingletonPlugin):
         return self._update_facets(facets_dict)
 
         # IAuthFunctions
+
     def get_auth_functions(self):
-        return {
-            'config_option_show': auth_get.config_option_show
-        }
+        return {"config_option_show": config_option_show}
 
     def get_actions(self):
         return {
-            'scheming_package_show': action_get.scheming_package_show
+            "scheming_package_show": scheming_package_show,
+            "theme_list": get_theme_list,
+            "publisher_list": get_publisher_list,
+            "keyword_list": get_keyword_list,
+            "catalogue_list": get_catalogue_list,
+            "dataset_list": get_dataset_list,
         }


### PR DESCRIPTION
Add 5 new endpoints.

Each endpoint allows to fetch the count of a certain label along with its unique values. 

Endpoints cover Theme, Publisher (name), Keywords, Catalogues, and Datasets.

To achieve this, I made use of the "package_search" and I parsed the data iterating batch-by-batch (to avoid memory issues).

Example of the response payload when querying "/api/action/keyword_list": 

```
{"help": "http://localhost:5500/api/3/action/help_show?name=keyword_list", "success": true, "result": {"count": 430, "results": ["patients", "Drug abuse", "Cancer registry", "spinal muscular atrophy", "biomodels", "case fatality", "Health protection", "demography", "Health Monitoring", "Annual statistics", "Risk factors", "dementia", "New psychoactive substances", "Population demograpics", "organ recipient", "Municipalities", "smoking", "medical specialty", "Healthcare facilities", "registry", "communicable diseases", "health services", "Financial support", "all-cause mortality", "brain", "drug resistance", "Safety and Healthcare Record Information Reuse", "Turnover", "Public health surveillance", "Children", "Epidemiology", "Protective effect", "rickets", "appointments", "nurses", "reproductive health", "injuries", "Perinatal mortality", "Diagnoses", "lifestyle", "Influenza", "Prevalence", "kidney stones", "determinants of health", "Healthcare expenditure"]}}
```
### Note
 
Home counters can be a bit slow to appear. We may want to modify a bit the endpoints to get only the counts when we don't need the values of a field.