### PR TITLE
check key existence before trying to get the value from a dataset for…

### DIFF
--- a/ckanext/gdi_userportal/logic/action/fetcher/dataset_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/dataset_fetcher.py
@@ -2,8 +2,6 @@ from ckanext.gdi_userportal.logic.action.fetcher.prop_fetcher import PropFetcher
 
 
 class DatasetFetcher(PropFetcher):
-    def _get_batched_prop_values(self, batched_datasets):
-        prop_name = "name"
-        return [
-            dataset[prop_name] for dataset in batched_datasets if prop_name in dataset
-        ]
+    @property
+    def _prop_name() -> str:
+        return "name"

--- a/ckanext/gdi_userportal/logic/action/fetcher/dataset_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/dataset_fetcher.py
@@ -3,4 +3,7 @@ from ckanext.gdi_userportal.logic.action.fetcher.prop_fetcher import PropFetcher
 
 class DatasetFetcher(PropFetcher):
     def _get_batched_prop_values(self, batched_datasets):
-        return [dataset["name"] for dataset in batched_datasets]
+        prop_name = "name"
+        return [
+            dataset[prop_name] for dataset in batched_datasets if prop_name in dataset
+        ]

--- a/ckanext/gdi_userportal/logic/action/fetcher/dataset_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/dataset_fetcher.py
@@ -3,5 +3,5 @@ from ckanext.gdi_userportal.logic.action.fetcher.prop_fetcher import PropFetcher
 
 class DatasetFetcher(PropFetcher):
     @property
-    def _prop_name() -> str:
+    def _prop_name(self) -> str:
         return "name"

--- a/ckanext/gdi_userportal/logic/action/fetcher/prop_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/prop_fetcher.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC, abstractproperty
 
 from ckan.plugins import toolkit
 
@@ -33,6 +33,13 @@ class PropFetcher(ABC):
         )["results"]
         return datasets
 
-    @abstractmethod
     def _get_batched_prop_values(self, batched_datasets: list[dict]) -> list[str]:
+        return [
+            dataset[self._prop_name]
+            for dataset in batched_datasets
+            if self._prop_name in dataset
+        ]
+
+    @abstractproperty
+    def _prop_name() -> str:
         pass

--- a/ckanext/gdi_userportal/logic/action/fetcher/prop_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/prop_fetcher.py
@@ -41,5 +41,5 @@ class PropFetcher(ABC):
         ]
 
     @abstractproperty
-    def _prop_name() -> str:
+    def _prop_name(self) -> str:
         pass

--- a/ckanext/gdi_userportal/logic/action/fetcher/publisher_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/publisher_fetcher.py
@@ -3,5 +3,5 @@ from ckanext.gdi_userportal.logic.action.fetcher.prop_fetcher import PropFetcher
 
 class PublisherFetcher(PropFetcher):
     @property
-    def _prop_name() -> str:
+    def _prop_name(self) -> str:
         return "publisher_name"

--- a/ckanext/gdi_userportal/logic/action/fetcher/publisher_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/publisher_fetcher.py
@@ -3,5 +3,8 @@ from ckanext.gdi_userportal.logic.action.fetcher.prop_fetcher import PropFetcher
 
 class PublisherFetcher(PropFetcher):
     def _get_batched_prop_values(self, batched_datasets) -> list[str]:
-        publishers = set([dataset["publisher_name"] for dataset in batched_datasets])
+        prop_name = "publisher_name"
+        publishers = set(
+            [dataset[prop_name] for dataset in batched_datasets if prop_name in dataset]
+        )
         return publishers

--- a/ckanext/gdi_userportal/logic/action/fetcher/publisher_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/publisher_fetcher.py
@@ -2,9 +2,6 @@ from ckanext.gdi_userportal.logic.action.fetcher.prop_fetcher import PropFetcher
 
 
 class PublisherFetcher(PropFetcher):
-    def _get_batched_prop_values(self, batched_datasets) -> list[str]:
-        prop_name = "publisher_name"
-        publishers = set(
-            [dataset[prop_name] for dataset in batched_datasets if prop_name in dataset]
-        )
-        return publishers
+    @property
+    def _prop_name() -> str:
+        return "publisher_name"

--- a/ckanext/gdi_userportal/logic/action/fetcher/theme_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/theme_fetcher.py
@@ -10,5 +10,5 @@ class ThemeFetcher(PropFetcher):
         return themes
 
     @property
-    def _prop_name() -> str:
+    def _prop_name(self) -> str:
         return "theme"

--- a/ckanext/gdi_userportal/logic/action/fetcher/theme_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/theme_fetcher.py
@@ -5,9 +5,10 @@ from ckanext.gdi_userportal.logic.action.fetcher.prop_fetcher import PropFetcher
 
 class ThemeFetcher(PropFetcher):
     def _get_batched_prop_values(self, batched_datasets) -> list[str]:
-        prop_name = "theme"
-        themes = [
-            dataset[prop_name] for dataset in batched_datasets if prop_name in dataset
-        ]
+        themes = super()._get_batched_prop_values(batched_datasets)
         themes = list(set(reduce(lambda themes1, themes2: themes1 + themes2, themes)))
         return themes
+
+    @property
+    def _prop_name() -> str:
+        return "theme"

--- a/ckanext/gdi_userportal/logic/action/fetcher/theme_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/theme_fetcher.py
@@ -5,6 +5,9 @@ from ckanext.gdi_userportal.logic.action.fetcher.prop_fetcher import PropFetcher
 
 class ThemeFetcher(PropFetcher):
     def _get_batched_prop_values(self, batched_datasets) -> list[str]:
-        themes = [dataset["theme"] for dataset in batched_datasets]
+        prop_name = "theme"
+        themes = [
+            dataset[prop_name] for dataset in batched_datasets if prop_name in dataset
+        ]
         themes = list(set(reduce(lambda themes1, themes2: themes1 + themes2, themes)))
         return themes


### PR DESCRIPTION
Some datasets can have no publisher_name or theme, causing issues.

This fixes the problem by checking that the key does exist in the dataset before trying to retrieve the value.