### PR TITLE
fix(theme-fetcher): handle empty iterable in theme reduction process

### DIFF
--- a/ckanext/gdi_userportal/logic/action/fetcher/theme_fetcher.py
+++ b/ckanext/gdi_userportal/logic/action/fetcher/theme_fetcher.py
@@ -1,16 +1,15 @@
 # SPDX-FileCopyrightText: 2024 PNED G.I.E.
-#
+# SPDX-FileContributor: Stichting Health-RI
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import reduce
 
 from ckanext.gdi_userportal.logic.action.fetcher.prop_fetcher import PropFetcher
 
-
 class ThemeFetcher(PropFetcher):
     def _get_batched_prop_values(self, batched_datasets) -> list[str]:
         themes = super()._get_batched_prop_values(batched_datasets)
-        themes = list(set(reduce(lambda themes1, themes2: themes1 + themes2, themes)))
+        themes = list(set(reduce(lambda themes1, themes2: themes1 + themes2, themes, [])))
         return themes
 
     @property


### PR DESCRIPTION
This commit addresses an issue where the `reduce` function in the `ThemeFetcher` class would throw an error when called with an empty iterable. By providing an initial value (an empty list), we ensure that the function can handle empty datasets gracefully, preventing runtime errors.

Closes #35