### PR TITLE
chore: change schema to accept multiValues contact points with repeating subfields

### DIFF
--- a/ckanext/gdi_userportal/scheming/schemas/gdi_userportal.json
+++ b/ckanext/gdi_userportal/scheming/schemas/gdi_userportal.json
@@ -114,35 +114,47 @@
       }
     },
     {
-      "field_name": "contact_uri",
+      "field_name": "contact_point",
       "help_inline": true,
       "help_text": {
         "en": "[dcat:contactPoint] This property contains contact information that can be used for sending comments about the Dataset."
       },
       "label": {
-        "en": "Contact URI"
-      }
-    },
-    {
-      "field_name": "contact_name",
-      "label": {
-        "en": "Contact Name"
+        "en": "Contact Point"
       },
-      "help_inline": true,
-      "help_text": {
-        "en": "[vcard:fn] This property contains contact information that can be used for sending comments about the Dataset."
-      }
-    },
-    {
-      "field_name": "contact_email",
-      "help_inline": true,
-      "help_text": {
-        "en": "[vcard:hasEmail] This property contains contact information that can be used for sending comments about the Dataset."
-      },
-      "label": {
-        "en": "Contact Email"
-      },
-      "display_snippet": "email.html"
+      "repeating_subfields": [
+        {
+          "field_name": "contact_uri",
+          "help_inline": true,
+          "help_text": {
+            "en": "[dcat:contactPoint] This property contains contact information that can be used for sending comments about the Dataset."
+          },
+          "label": {
+          "en": "Contact URI"
+          }
+        },
+        {
+          "field_name": "contact_name",
+          "label": {
+            "en": "Contact Name"
+          },
+          "help_inline": true,
+          "help_text": {
+            "en": "[vcard:fn] This property contains contact information that can be used for sending comments about the Dataset."
+          }
+        },
+        {
+          "field_name": "contact_email",
+          "help_inline": true,
+          "help_text": {
+            "en": "[vcard:hasEmail] This property contains contact information that can be used for sending comments about the Dataset."
+          },
+          "label": {
+            "en": "Contact Email"
+          },
+          "display_snippet": "email.html"
+        }
+      ]
     },
     {
       "field_name": "publisher_uri",

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -160,6 +160,7 @@ attribute with the form `ckan-X.Y` -->
         <field name="provenance" type="string" indexed="true" stored="true" multiValued="false" />
         <field name="spatial_uri" type="string" indexed="true" stored="true" multiValued="false" />
         <field name="contact_uri" type="string" indexed="true" stored="true" multiValued="false" />
+        <field name="contact_point" type="string" indexed="true" stored="true" multiValued="true" />
         <field name="resources_formats" type="string" indexed="true" stored="true"
             multiValued="true" />
         <field name="publisher_name" type="string" indexed="true" stored="true" multiValued="false" />


### PR DESCRIPTION
changes to complete https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-fairdatapoint/pull/21
CKAN scheme: add contact_point field with nested repeating subfields
Solr scheme: allow multiple values for contact_point
plugin: convert contact_point objects to jsonld to avoid solr errors (see docs https://github.com/ckan/ckanext-scheming/tree/master?tab=readme-ov-file#repeating_subfields)