### PR TITLE
feat: Enhance creator parsing in DCAT profile and ckan

### DIFF
--- a/ckanext/gdi_userportal/scheming/schemas/gdi_userportal.json
+++ b/ckanext/gdi_userportal/scheming/schemas/gdi_userportal.json
@@ -332,14 +332,36 @@
     },
     {
       "field_name": "creator",
-      "label": {
-        "en": "Creator"
-      },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:creator] This property refers to the  entity responsible for producing the dataset."
-      }
-    },
+          "en": "[dct:creator] The entity responsible for producing the resource."
+      },
+      "label": {
+          "en": "Creator"
+      },
+      "repeating_subfields": [
+          {
+              "field_name": "creator_identifier",
+              "help_inline": true,
+              "help_text": {
+                  "en": "[dct:identifier] Unique identification of the person/organisation."
+              },
+              "label": {
+                  "en": "Creator URI"
+              }
+          },
+          {
+              "field_name": "creator_name",
+              "label": {
+                  "en": "Creator Name"
+              },
+              "help_inline": true,
+              "help_text": {
+                  "en": "[foaf:name] This property contains the name of the creator."
+              }
+          }
+      ]
+  },
     {
       "field_name": "is_referenced_by",
       "label": {


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the 'creator' field in the DCAT profile and CKAN schema by adding support for repeating subfields, including 'creator_identifier' and 'creator_name', and update the help text for better clarity.

New Features:
- Add support for repeating subfields in the 'creator' field, including 'creator_identifier' and 'creator_name'.

Enhancements:
- Update the help text for the 'creator' field to provide a clearer description.

<!-- Generated by sourcery-ai[bot]: end summary -->