### PR TITLE
Flexible datetime scheming

### DIFF
--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,9 +1,27 @@
+ckanext-scheming - Terms and Conditions of Use
+
+Part of the gdi-userportal extension is derived from ckanext-scheming.
+
+Unless otherwise noted, computer program source code of ckanext-scheming is
+covered under Crown Copyright, Government of Canada, and is distributed under the MIT License.
+
+
 MIT License
 
-Copyright (c) <year> <copyright holders>
+Copyright (c) His Majesty the King in Right of Canada, represented by the President of the Treasury
+Board, 2013-2018
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/ckanext/gdi_userportal/scheming/presets/gdi_presets.json
+++ b/ckanext/gdi_userportal/scheming/presets/gdi_presets.json
@@ -6,8 +6,8 @@
         {
             "preset_name": "datetime_flex",
             "values": {
-                "form_snippet": "datetime_tz.html",
-                "display_snippet": "datetime_tz.html",
+                "form_snippet": "datetime.html",
+                "display_snippet": "datetime.html",
                 "validators": "scheming_isodatetime_flex convert_to_json_if_datetime"
             }
         }

--- a/ckanext/gdi_userportal/scheming/presets/gdi_presets.json
+++ b/ckanext/gdi_userportal/scheming/presets/gdi_presets.json
@@ -1,0 +1,15 @@
+{
+    "scheming_presets_version": 1,
+    "about": "GDI scheming field presets",
+    "about_url": "https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal/",
+    "presets": [
+        {
+            "preset_name": "datetime_flex",
+            "values": {
+                "form_snippet": "datetime_tz.html",
+                "display_snippet": "datetime_tz.html",
+                "validators": "scheming_isodatetime_flex convert_to_json_if_datetime"
+            }
+        }
+    ]
+}

--- a/ckanext/gdi_userportal/scheming/presets/gdi_presets.json.license
+++ b/ckanext/gdi_userportal/scheming/presets/gdi_presets.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 Stichting Health-RI
+
+SPDX-License-Identifier: Apache-2.0

--- a/ckanext/gdi_userportal/scheming/schemas/gdi_userportal.json
+++ b/ckanext/gdi_userportal/scheming/schemas/gdi_userportal.json
@@ -225,7 +225,7 @@
       "label": {
         "en": "Temportal Start Date"
       },
-      "preset": "date"
+      "preset": "datetime_flex"
     },
     {
       "field_name": "temporal_end",
@@ -236,7 +236,7 @@
       "label": {
         "en": "Temporal end date"
       },
-      "preset": "date"
+      "preset": "datetime_flex"
     },
     {
       "field_name": "theme",
@@ -401,7 +401,7 @@
       "help_text": {
         "en": "[dct:issued] This property contains the date of formal issuance (e.g., publication) of the Dataset."
       },
-      "preset": "date"
+      "preset": "datetime_flex"
     },
     {
       "field_name": "language",
@@ -419,7 +419,7 @@
       "label": {
         "en": "Modification Date"
       },
-      "preset": "date",
+      "preset": "datetime_flex",
       "help_inline": true,
       "help_text": {
         "en": "[dct:modified] This property contains the most recent date on which the Dataset was changed or modified."

--- a/ckanext/gdi_userportal/tests/test_scheming.py
+++ b/ckanext/gdi_userportal/tests/test_scheming.py
@@ -26,9 +26,9 @@ def time_nye():
         # Time ahead
         pytz.timezone("CET").localize(datetime(2020, 1, 1, 1, 0)),
         # Time behind
-        pytz.timezone("America/Chicago").localize(datetime(2019, 12, 31, 18, 0)),
-        # Timezone with more than just hours
-        pytz.timezone("Asia/Kolkata").localize(datetime(2020, 1, 1, 5, 30)),
+        pytz.timezone("America/Chicago").localize(datetime(2019, 12, 31, 18, 0, 0)),
+        # Timezone with more than just hours and microseconds
+        pytz.timezone("Asia/Kolkata").localize(datetime(2020, 1, 1, 5, 30, 0, 987654)),
     ],
 )
 def test_utc_enforcer(time, time_nye):

--- a/ckanext/gdi_userportal/tests/test_scheming.py
+++ b/ckanext/gdi_userportal/tests/test_scheming.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2024 Stichting Health-RI
+#
+# SPDX-License-Identifier: MIT
+
+"""
+This module tests the scheming related parts of the GDI userportal plugin (validation.py)
+"""
+
+from datetime import datetime
+
+import ckanext.gdi_userportal.validation as validation
+import pytest
+import pytz
+
+
+@pytest.fixture
+def time_nye():
+    return datetime(2020, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
+
+
+@pytest.mark.parametrize(
+    "time",
+    [
+        # No timezone defined
+        datetime(2020, 1, 1),
+        # Time ahead
+        pytz.timezone("CET").localize(datetime(2020, 1, 1, 1, 0)),
+        # Time behind
+        pytz.timezone("America/Chicago").localize(datetime(2019, 12, 31, 18, 0)),
+        # Timezone with more than just hours
+        pytz.timezone("Asia/Kolkata").localize(datetime(2020, 1, 1, 5, 30)),
+    ],
+)
+def test_utc_enforcer(time, time_nye):
+    assert validation.enforce_utc_time(time) == time_nye

--- a/ckanext/gdi_userportal/tests/test_scheming.py
+++ b/ckanext/gdi_userportal/tests/test_scheming.py
@@ -32,4 +32,6 @@ def time_nye():
     ],
 )
 def test_utc_enforcer(time, time_nye):
-    assert validation.enforce_utc_time(time) == time_nye
+    result = validation.enforce_utc_time(time)
+    assert result == time_nye
+    assert result.tzinfo == pytz.UTC

--- a/ckanext/gdi_userportal/validation.py
+++ b/ckanext/gdi_userportal/validation.py
@@ -14,7 +14,7 @@ not_empty = get_validator("not_empty")
 
 
 def enforce_utc_time(dt: datetime) -> datetime:
-    """This function ensures a datetime object is always in UTC time.
+    """This function ensures a datetime object is always in UTC time with second accuracy.
 
     If no timezone is specified, it is presumed to be UTC time.
 
@@ -29,6 +29,9 @@ def enforce_utc_time(dt: datetime) -> datetime:
         Datetime object in UTC time
 
     """
+    # Cut off microseconds, we don't need that much accuracy
+    dt = dt.replace(microsecond=0)
+
     if not dt.tzinfo:
         out_date = dt.replace(tzinfo=pytz.UTC)
     else:

--- a/ckanext/gdi_userportal/validation.py
+++ b/ckanext/gdi_userportal/validation.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: His Majesty the King in Right of Canada, His Majesty the King in Right of Canada, represented by the President of the Treasury Board
+# SPDX-FileContributor: Stichting Health-RI
+#
+# SPDX-License-Identifier: MIT
+
+import datetime
+
+import pytz
+from ckanext.scheming.validation import register_validator, scheming_validator
+from ckantoolkit import Invalid, _, get_validator
+from dateutil.parser import ParserError, parse
+
+not_empty = get_validator("not_empty")
+
+
+def validate_datetime_flex_inputs(
+    field, key, data, extras, errors, context
+) -> datetime.datetime:
+    """This function validates datetime inputs with a timezone accordng to ISO 8601
+
+    If timezone is not set, will localize the datetime object to add the timezone."""
+    date_error = _("Date format incorrect")
+    time_error = _("Time format incorrect")
+
+    date = None
+
+    def get_input(suffix):
+        inpt = key[0] + "_" + suffix
+        new_key = (inpt,) + tuple(x for x in key if x != key[0])
+        key_value = extras.get(inpt)
+        data[new_key] = key_value
+        errors[new_key] = []
+
+        if key_value:
+            del extras[inpt]
+
+        if field.get("required"):
+            not_empty(new_key, data, errors, context)
+
+        return new_key, key_value
+
+    date_key, date_value = get_input("date")
+
+    if date_value:
+        try:
+            date = parse(date_value)
+        except (TypeError, ValueError) as e:
+            errors[date_key].append(date_error)
+
+    time_key, time_value = get_input("time")
+    if time_value:
+        if not date_value:
+            errors[date_key].append(_("Date is required when a time is provided"))
+        else:
+            try:
+                value_full = f"{date_value}T{time_value}"
+                date = parse(value_full)
+            except (TypeError, ValueError) as e:
+                errors[time_key].append(time_error)
+
+    tz_key, tz_value = get_input("tz")
+    if tz_value:
+        if tz_value not in pytz.all_timezones:
+            errors[tz_key].append("Invalid timezone")
+        else:
+            if isinstance(date, datetime.datetime):
+                date = pytz.timezone(tz_value).localize(date)
+
+    return date
+
+
+@register_validator
+@scheming_validator
+def scheming_isodatetime_flex(field, schema):
+    """This scheming validator is very similar to the upstream one, but uses the parser from
+    dateutil, which is a bit more robust and can also handle missing timestamps from inputs.
+    """
+
+    def validator(key, data, errors, context):
+        value = data[key]
+        date = None
+
+        # If we get a value for the key, check if it's a datetime else make it one
+        if value:
+            if isinstance(value, datetime.datetime):
+                date = value
+            else:
+                try:
+                    date = parse(value)
+                except (ValueError, TypeError):
+                    raise Invalid(_("Datetime format incorrect"))
+        else:
+            # Else try to combine existing fields (extras date and time) into a datetime object
+            extras = data.get(("__extras",))
+            if not extras or (
+                f"{key[0]}_date" not in extras and f"{key[0]}_time" not in extras
+            ):
+                if field.get("required"):
+                    not_empty(key, data, errors, context)
+            else:
+                date = validate_datetime_flex_inputs(
+                    field, key, data, extras, errors, context
+                )
+
+        data[key] = date
+
+    return validator

--- a/ckanext/gdi_userportal/validation.py
+++ b/ckanext/gdi_userportal/validation.py
@@ -85,7 +85,8 @@ def validate_datetime_flex_inputs(
             except (TypeError, ValueError):
                 errors[time_key].append(time_error)
     else:
-        date = date.replace(hour=12)
+        if isinstance(date, datetime):
+            date.replace(hour=12)
 
     tz_key, tz_value = get_input("tz")
     if tz_value:
@@ -130,8 +131,9 @@ def scheming_isodatetime_flex(field, schema):
                 date = validate_datetime_flex_inputs(
                     field, key, data, extras, errors, context
                 )
+        if date:
+            date = enforce_utc_time(date)
 
-        utc_date = enforce_utc_time(date)
-        data[key] = utc_date
+        data[key] = date
 
     return validator

--- a/ckanext/gdi_userportal/validation.py
+++ b/ckanext/gdi_userportal/validation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: His Majesty the King in Right of Canada, His Majesty the King in Right of Canada, represented by the President of the Treasury Board
+# SPDX-FileCopyrightText: His Majesty the King in Right of Canada, represented by the President of the Treasury Board
 # SPDX-FileContributor: Stichting Health-RI
 #
 # SPDX-License-Identifier: MIT
@@ -8,9 +8,33 @@ from datetime import datetime
 import pytz
 from ckanext.scheming.validation import register_validator, scheming_validator
 from ckantoolkit import Invalid, _, get_validator
-from dateutil.parser import ParserError, isoparse
+from dateutil.parser import isoparse
 
 not_empty = get_validator("not_empty")
+
+
+def enforce_utc_time(dt: datetime) -> datetime:
+    """This function ensures a datetime object is always in UTC time.
+
+    If no timezone is specified, it is presumed to be UTC time.
+
+    Parameters
+    ----------
+    dt : datetime
+        Datetime object to be set to UTC time
+
+    Returns
+    -------
+    datetime
+        Datetime object in UTC time
+
+    """
+    if not dt.tzinfo:
+        out_date = dt.replace(tzinfo=pytz.UTC)
+    else:
+        out_date = dt.astimezone(pytz.UTC)
+
+    return out_date
 
 
 def validate_datetime_flex_inputs(
@@ -44,7 +68,7 @@ def validate_datetime_flex_inputs(
     if date_value:
         try:
             date = isoparse(date_value)
-        except (TypeError, ValueError) as e:
+        except (TypeError, ValueError):
             errors[date_key].append(date_error)
 
     time_key, time_value = get_input("time")
@@ -55,7 +79,7 @@ def validate_datetime_flex_inputs(
             try:
                 value_full = f"{date_value}T{time_value}"
                 date = isoparse(value_full)
-            except (TypeError, ValueError) as e:
+            except (TypeError, ValueError):
                 errors[time_key].append(time_error)
     else:
         date = date.replace(hour=12)
@@ -69,30 +93,6 @@ def validate_datetime_flex_inputs(
                 date = pytz.timezone(tz_value).localize(date)
 
     return date
-
-
-def enforce_utc_time(dt: datetime) -> datetime:
-    """This function ensures a datetime object is always in UTC time.
-
-    If no timezone is specified, it is presumed to be UTC time.
-
-    Parameters
-    ----------
-    dt : datetime
-        Datetime object to be set to UTC time
-
-    Returns
-    -------
-    datetime
-        Datetime object in UTC time
-
-    """
-    if not dt.tzinfo:
-        out_date = dt.replace(tzinfo=pytz.UTC)
-    else:
-        out_date = dt.astimezone(pytz.UTC)
-
-    return out_date
 
 
 @register_validator

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Stichting Health-RI
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # CKAN requires 2.9.0, we are slightly less picky
 python-dateutil >= 2.8.1
+pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# CKAN requires 2.9.0, we are slightly less picky
+python-dateutil >= 2.8.1


### PR DESCRIPTION
This PR adds a new scheming field, datetime_flex, which is more flexible in what it accepts than standard CKAN. It uses dateutil to parse any ISO8601 string and turn it into RFC 3339 full-time format.

Timezone is added if not present in the original timestamp, local time of CKAN is used.

Note: will need changes to the Docker too, to use new presets.json; I'll create a PR of that, too. I'll also add some unit testing for this later.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a flexible datetime scheming field 'datetime_flex' to enhance date parsing capabilities, including a new validator for handling ISO8601 strings and ensuring UTC conversion. Update schema presets and add corresponding unit tests.

New Features:
- Introduce a new scheming field 'datetime_flex' that uses dateutil to parse ISO8601 strings and convert them to RFC 3339 full-time format, adding timezone information if missing.

Enhancements:
- Implement a new validator 'scheming_isodatetime_flex' to handle flexible datetime parsing and validation, ensuring datetime objects are in UTC.

Tests:
- Add unit tests for the UTC enforcement function to ensure datetime objects are correctly converted to UTC.

<!-- Generated by sourcery-ai[bot]: end summary -->