### PR TITLE
feat(scheming): added Dutch translation to all fields for the Scheming

### DIFF
--- a/ckanext/gdi_userportal/scheming/schemas/gdi_userportal.json
+++ b/ckanext/gdi_userportal/scheming/schemas/gdi_userportal.json
@@ -6,11 +6,15 @@
   "dataset_fields": [
     {
       "field_name": "title",
-      "label": "Title",
+      "label": {
+        "en": "Title",
+        "nl": "Titel"
+      },
       "preset": "title",
       "help_inline": true,
       "help_text": {
-        "en": "[dct:title] This property contains a name given to the Dataset."
+        "en": "[dct:title] This property contains a name given to the Dataset.",
+        "nl": "[dct:title] Deze eigenschap bevat een naam voor de Dataset."
       }
     },
     {
@@ -26,7 +30,8 @@
       "required": true,
       "help_inline": true,
       "help_text": {
-        "en": "[dct:description] This property contains a free-text account of the Dataset."
+        "en": "[dct:description] This property contains a free-text account of the Dataset.",
+        "nl": "[dct:description] Deze eigenschap bevat een vrije tekstbeschrijving van de Dataset."
       }
     },
     {
@@ -35,7 +40,8 @@
       "preset": "tag_string_autocomplete",
       "help_inline": true,
       "help_text": {
-        "en": "[dcat:keyword] This property contains a keyword or tag describing the Dataset."
+        "en": "[dcat:keyword] This property contains a keyword or tag describing the Dataset.",
+        "nl": "[dcat:keyword] Deze eigenschap bevat een sleutelwoord of tag die de Dataset beschrijft."
       }
     },
     {
@@ -44,7 +50,8 @@
       "form_snippet": "license.html",
       "help_inline": true,
       "help_text": {
-        "en": "[dct:license] This property refers to the license under which the Dataset is made available."
+        "en": "[dct:license] This property refers to the license under which the Dataset is made available.",
+        "nl": "[dct:license] Deze eigenschap verwijst naar de licentie waaronder de Dataset beschikbaar is gesteld."
       }
     },
     {
@@ -60,7 +67,8 @@
       "display_snippet": "link.html",
       "help_inline": true,
       "help_text": {
-        "en": "[dcat:landingPage] This property refers to a web page that provides access to the Dataset, its Distributions and/or additional information. It is intended to point to a landing page at the original data provider, not to a page on a site of a third party, such as an aggregator."
+        "en": "[dcat:landingPage] This property refers to a web page that provides access to the Dataset, its Distributions and/or additional information. It is intended to point to a landing page at the original data provider, not to a page on a site of a third party, such as an aggregator.",
+        "nl": "[dcat:landingPage] Deze eigenschap verwijst naar een webpagina die toegang biedt tot de Dataset, haar Distributies en/of aanvullende informatie. Het is bedoeld om te verwijzen naar een landingspagina bij de oorspronkelijke dataleverancier, niet naar een pagina op een site van derden, zoals een aggregator."
       }
     },
     {
@@ -70,7 +78,8 @@
       "form_placeholder": "1.0",
       "help_inline": true,
       "help_text": {
-        "en": "[owl:versionInfo] This property contains a version number or other version designation of the Dataset."
+        "en": "[owl:versionInfo] This property contains a version number or other version designation of the Dataset.",
+        "nl": "[owl:versionInfo] Deze eigenschap bevat een versienummer of andere versieaanduiding van de Dataset."
       }
     },
     {
@@ -79,7 +88,8 @@
       "form_placeholder": "Joe Bloggs",
       "help_inline": true,
       "help_text": {
-        "en": "[CKAN] Fallback value for [vcard:fn]"
+        "en": "[CKAN] Fallback value for [vcard:fn]",
+        "nl": "[CKAN] Fallback-waarde voor [vcard:fn]"
       }
     },
     {
@@ -90,7 +100,8 @@
       "display_email_name_field": "author",
       "help_inline": true,
       "help_text": {
-        "en": "[CKAN] Fallback value for [vcard:hasEmail]"
+        "en": "[CKAN] Fallback value for [vcard:hasEmail]",
+        "nl": "[CKAN] Fallback-waarde voor [vcard:hasEmail]"
       }
     },
     {
@@ -99,7 +110,8 @@
       "form_placeholder": "Joe Bloggs",
       "help_inline": true,
       "help_text": {
-        "en": "[CKAN] Fallback value for [vcard:fn]"
+        "en": "[CKAN] Fallback value for [vcard:fn]",
+        "nl": "[CKAN] Fallback-waarde voor [vcard:fn]"
       }
     },
     {
@@ -110,47 +122,56 @@
       "display_email_name_field": "maintainer",
       "help_inline": true,
       "help_text": {
-        "en": "[CKAN] Fallback value for [vcard:hasEmail]"
+        "en": "[CKAN] Fallback value for [vcard:hasEmail]",
+        "nl": "[CKAN] Fallback-waarde voor [vcard:hasEmail]"
       }
     },
     {
       "field_name": "contact_point",
       "help_inline": true,
       "help_text": {
-        "en": "[dcat:contactPoint] This property contains contact information that can be used for sending comments about the Dataset."
+        "en": "[dcat:contactPoint] This property contains contact information that can be used for sending comments about the Dataset.",
+        "nl": "[dcat:contactPoint] Deze eigenschap bevat contactgegevens die kunnen worden gebruikt voor het verzenden van opmerkingen over de Dataset."
       },
       "label": {
-        "en": "Contact Point"
+        "en": "Contact Point",
+        "nl": "Contactpunt"
       },
       "repeating_subfields": [
         {
           "field_name": "contact_uri",
           "help_inline": true,
           "help_text": {
-            "en": "[dcat:contactPoint] This property contains contact information that can be used for sending comments about the Dataset."
+            "en": "[dcat:contactPoint] This property contains contact information that can be used for sending comments about the Dataset.",
+            "nl": "[dcat:contactPoint] Deze eigenschap bevat contactgegevens die kunnen worden gebruikt voor het verzenden van opmerkingen over de Dataset."
           },
           "label": {
-            "en": "Contact URI"
+            "en": "Contact URI",
+            "nl": "Contact URI"
           }
         },
         {
           "field_name": "contact_name",
           "label": {
-            "en": "Contact Name"
+            "en": "Contact Name",
+            "nl": "Contactnaam"
           },
           "help_inline": true,
           "help_text": {
-            "en": "[vcard:fn] This property contains contact information that can be used for sending comments about the Dataset."
+            "en": "[vcard:fn] This property contains contact information that can be used for sending comments about the Dataset.",
+            "nl": "[vcard:fn] Deze eigenschap bevat contactgegevens die kunnen worden gebruikt voor het verzenden van opmerkingen over de Dataset."
           }
         },
         {
           "field_name": "contact_email",
           "help_inline": true,
           "help_text": {
-            "en": "[vcard:hasEmail] This property contains contact information that can be used for sending comments about the Dataset."
+            "en": "[vcard:hasEmail] This property contains contact information that can be used for sending comments about the Dataset.",
+            "nl": "[vcard:hasEmail] Deze eigenschap bevat contactgegevens die kunnen worden gebruikt voor het verzenden van opmerkingen over de Dataset."
           },
           "label": {
-            "en": "Contact Email"
+            "en": "Contact Email",
+            "nl": "Contact E-mail"
           },
           "display_snippet": "email.html"
         }
@@ -159,71 +180,85 @@
     {
       "field_name": "publisher_uri",
       "label": {
-        "en": "Publisher"
+        "en": "Publisher",
+        "nl": "Publicerende organisatie"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:publisher] This property refers to an entity (organisation) responsible for making the Dataset available."
+        "en": "[dct:publisher] This property refers to an entity (organisation) responsible for making the Dataset available.",
+        "nl": "[dct:publisher] Deze eigenschap verwijst naar een entiteit (organisatie) die verantwoordelijk is voor het beschikbaar stellen van de Dataset."
       }
     },
     {
       "field_name": "publisher_name",
       "label": {
-        "en": "Publisher Name"
+        "en": "Publisher Name",
+        "nl": "Naam publicerende organisatie"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[foaf:name] This property contains a name of the agent."
+        "en": "[foaf:name] This property contains a name of the agent.",
+        "nl": "[foaf:name] Deze eigenschap bevat een naam van de agent."
       }
     },
     {
       "field_name": "publisher_email",
       "label": {
-        "en": "Publisher Email"
+        "en": "Publisher Email",
+        "nl": "E-mail publicerende organisatie"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[foaf:mbox] This property contains an email of the agent."
+        "en": "[foaf:mbox] This property contains an email of the agent.",
+        "nl": "[foaf:mbox] Deze eigenschap bevat een e-mailadres van de agent."
       }
     },
     {
       "field_name": "publisher_url",
       "label": {
-        "en": "Publisher URL"
+        "en": "Publisher URL",
+        "nl": "URL publicerende organisatie"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[foaf:homepage] This property refers to a web page that acts as the main page for the Catalogue."
+        "en": "[foaf:homepage] This property refers to a web page that acts as the main page for the Catalogue.",
+        "nl": "[foaf:homepage] Deze eigenschap verwijst naar een webpagina die fungeert als de hoofdpagina voor de Catalogus."
       }
     },
     {
       "field_name": "publisher_type",
       "label": {
-        "en": "Publisher Type"
+        "en": "Publisher Type",
+        "nl": "Type publicerende organisatie"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:type] This property refers to the type of the Dataset. "
+        "en": "[dct:type] This property refers to the type of the Dataset. ",
+        "nl": "[dct:type] Deze eigenschap verwijst naar het type van de Dataset."
       }
     },
     {
       "field_name": "spatial_uri",
       "label": {
-        "en": "Spatial URI"
+        "en": "Spatial URI",
+        "nl": "Spatiële URI"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:spatial] This property refers to a geographic region that is covered by the Dataset. "
+        "en": "[dct:spatial] This property refers to a geographic region that is covered by the Dataset. ",
+        "nl": "[dct:spatial] Deze eigenschap verwijst naar een geografisch gebied dat door de Dataset wordt gedekt."
       }
     },
     {
       "field_name": "temporal_start",
       "help_inline": true,
       "help_text": {
-        "en": "[dct:temporal] This property refers to a temporal period that the Dataset covers."
+        "en": "[dct:temporal] This property refers to a temporal period that the Dataset covers.",
+        "nl": "[dct:temporal] Deze eigenschap verwijst naar een tijdsperiode die door de Dataset wordt gedekt."
       },
       "label": {
-        "en": "Temportal Start Date"
+        "en": "Temporal Start Date",
+        "nl": "Begindatum tijdsperiode"
       },
       "preset": "date"
     },
@@ -231,133 +266,159 @@
       "field_name": "temporal_end",
       "help_inline": true,
       "help_text": {
-        "en": "[dct:temporal] This property refers to a temporal period that the Dataset covers."
+        "en": "[dct:temporal] This property refers to a temporal period that the Dataset covers.",
+        "nl": "[dct:temporal] Deze eigenschap verwijst naar een tijdsperiode die door de Dataset wordt gedekt."
       },
       "label": {
-        "en": "Temporal end date"
+        "en": "Temporal end date",
+        "nl": "Einddatum tijdsperiode"
       },
       "preset": "date"
     },
     {
       "field_name": "theme",
       "label": {
-        "en": "Theme"
+        "en": "Theme",
+        "nl": "Thema"
       },
       "preset": "multiple_text",
       "help_inline": true,
       "help_text": {
-        "en": "[dcat:theme] This property refers to a category of the Dataset. A Dataset may be associated with multiple themes."
+        "en": "[dcat:theme] This property refers to a category of the Dataset. A Dataset may be associated with multiple themes.",
+        "nl": "[dcat:theme] Deze eigenschap verwijst naar een categorie van de Dataset. Een Dataset kan zijn gekoppeld aan meerdere thema's."
       }
     },
     {
       "field_name": "version_notes",
       "label": {
-        "en": "Version Notes"
+        "en": "Version Notes",
+        "nl": "Versieopmerkingen"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[adms:versionNotes] This property contains a description of the differences between this version and a previous version of the Dataset."
+        "en": "[adms:versionNotes] This property contains a description of the differences between this version and a previous version of the Dataset.",
+        "nl": "[adms:versionNotes] Deze eigenschap bevat een beschrijving van de verschillen tussen deze versie en een vorige versie van de Dataset."
       }
     },
     {
       "field_name": "landing_page",
       "label": {
-        "en": "Landing Page"
+        "en": "Landing Page",
+        "nl": "Landingspagina"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dcat:landingPage] This property refers to a web page that provides access to the Dataset, its Distributions and/or additional information. It is intended to point to a landing page at the original data provider, not to a page on a site of a third party, such as an aggregator."
+        "en": "[dcat:landingPage] This property refers to a web page that provides access to the Dataset, its Distributions and/or additional information. It is intended to point to a landing page at the original data provider, not to a page on a site of a third party, such as an aggregator.",
+        "nl": "[dcat:landingPage] Deze eigenschap verwijst naar een webpagina die toegang biedt tot de Dataset, Distributies en/of aanvullende informatie. Het is bedoeld om te verwijzen naar een landingspagina bij de oorspronkelijke dataleverancier, niet naar een pagina op een site van derden, zoals een aggregator."
       }
     },
     {
       "field_name": "spatial_resolution_in_meters",
       "label": {
-        "en": "Spatial Resolution in Meters"
+        "en": "Spatial Resolution in Meters",
+        "nl": "Spatiële Resolutie in meters"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dcat:spatialResolutionInMeters] This property refers to the minimum spatial separation resolvable in a dataset, measured in meters."
+        "en": "[dcat:spatialResolutionInMeters] This property refers to the minimum spatial separation resolvable in a dataset, measured in meters.",
+        "nl": "[dcat:spatialResolutionInMeters] Deze eigenschap verwijst naar de meest precieze ruimtelijke resolutie in de dataset, gemeten in meters."
       }
     },
     {
       "field_name": "temporal_resolution",
       "label": {
-        "en": "Temporal Resolution"
+        "en": "Temporal Resolution",
+        "nl": "Tijdsresolutie"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dcat:temporalResolution] This property refers to the minimum time period resolvable in the dataset."
+        "en": "[dcat:temporalResolution] This property refers to the minimum time period resolvable in the dataset.",
+        "nl": "[dcat:temporalResolution] Deze eigenschap verwijst naar de meest precieze tijdsspanne in de dataset."
       }
     },
     {
       "field_name": "qualified_relation",
       "label": {
-        "en": "Qualified Relation"
+        "en": "Qualified Relation",
+        "nl": "Gekwalificeerde Relatie"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dcat:qualifiedRelation] This property provides a link to a description of a relationship with another resource."
+        "en": "[dcat:qualifiedRelation] This property provides a link to a description of a relationship with another resource.",
+        "nl": "[dcat:qualifiedRelation] Deze eigenschap biedt een link naar een beschrijving van een relatie met een andere bron."
       }
     },
     {
       "field_name": "access_rights",
       "label": {
-        "en": "Access rights"
+        "en": "Access rights",
+        "nl": "Toegangsrechten"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:accessRights] This property refers to information that indicates whether the Dataset is open data, has access restrictions or is not public."
+        "en": "[dct:accessRights] This property refers to information that indicates whether the Dataset is open data, has access restrictions or is not public.",
+        "nl": "[dct:accessRights] Deze eigenschap verwijst naar informatie die aangeeft of de Dataset open data is, toegangsbeperkingen heeft of niet openbaar is."
       }
     },
     {
       "field_name": "frequency",
       "label": {
-        "en": "Frequency"
+        "en": "Frequency",
+        "nl": "Frequentie"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:accrualPeriodicity] This property refers to the frequency at which the Dataset is updated."
+        "en": "[dct:accrualPeriodicity] This property refers to the frequency at which the Dataset is updated.",
+        "nl": "[dct:accrualPeriodicity] Deze eigenschap verwijst naar de frequentie waarmee de Dataset wordt bijgewerkt."
       }
     },
     {
       "field_name": "conforms_to",
       "label": {
-        "en": "Conforms to"
+        "en": "Conforms to",
+        "nl": "Voldoet aan"
       },
       "preset": "multiple_text",
       "help_inline": true,
       "help_text": {
-        "en": "[dct:conformsTo] This property refers to an implementing rule or other specification."
+        "en": "[dct:conformsTo] This property refers to an implementing rule or other specification.",
+        "nl": "[dct:conformsTo] Deze eigenschap verwijst naar geïmplementeerde regelgeving of een andere specificatie."
       }
     },
     {
       "field_name": "creator",
       "help_inline": true,
       "help_text": {
-        "en": "[dct:creator] The entity responsible for producing the resource."
+        "en": "[dct:creator] The entity responsible for producing the resource.",
+        "nl": "[dct:creator] De entiteit die verantwoordelijk is voor het produceren van de bron."
       },
       "label": {
-        "en": "Creator"
+        "en": "Creator",
+        "nl": "Maker"
       },
       "repeating_subfields": [
         {
           "field_name": "creator_identifier",
           "help_inline": true,
           "help_text": {
-            "en": "[dct:identifier] Unique identification of the person/organisation."
+            "en": "[dct:identifier] Unique identification of the person/organisation.",
+            "nl": "[dct:identifier] Unieke identificatie van de persoon/organisatie."
           },
           "label": {
-            "en": "Creator URI"
+            "en": "Creator URI",
+            "nl": "Maker URI"
           }
         },
         {
           "field_name": "creator_name",
           "label": {
-            "en": "Creator Name"
+            "en": "Creator Name",
+            "nl": "Naam maker"
           },
           "help_inline": true,
           "help_text": {
-            "en": "[foaf:name] This property contains the name of the creator."
+            "en": "[foaf:name] This property contains the name of the creator.",
+            "nl": "[foaf:name] Deze eigenschap bevat de naam van de maker."
           }
         }
       ]
@@ -365,165 +426,197 @@
     {
       "field_name": "is_referenced_by",
       "label": {
-        "en": "Is referenced by"
+        "en": "Is referenced by",
+        "nl": "Wordt gerefereerd door"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:isReferencedBy] This property is about a related resource, such as a publication, that references, cites, or otherwise points to the dataset."
+        "en": "[dct:isReferencedBy] This property is about a related resource, such as a publication, that references, cites, or otherwise points to the dataset.",
+        "nl": "[dct:isReferencedBy] Deze eigenschap is over een gerelateerde bron, zoals een publicatie, die verwijst, citeert of op een andere manier verwijst naar de dataset."
       }
     },
     {
       "field_name": "is_version_of",
       "label": {
-        "en": "Is version of"
+        "en": "Is version of",
+        "nl": "Is versie van"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:isVersionOf] This property refers to a related Dataset of which the described Dataset is a version, edition, or adaptation."
+        "en": "[dct:isVersionOf] This property refers to a related Dataset of which the described Dataset is a version, edition, or adaptation.",
+        "nl": "[dct:isVersionOf] Deze eigenschap verwijst naar een gerelateerde Dataset waarvan de beschreven Dataset een versie, editie of aanpassing is."
       }
     },
     {
       "field_name": "identifier",
       "label": {
-        "en": "Identifier"
+        "en": "Identifier",
+        "nl": "Identificatie"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:identifier] This property contains the main identifier for the Dataset, e.g. the URI or other unique identifier in the context of the Catalogue."
+        "en": "[dct:identifier] This property contains the main identifier for the Dataset, e.g. the URI or other unique identifier in the context of the Catalogue.",
+        "nl": "[dct:identifier] Deze eigenschap bevat de hoofdidentificatie voor de Dataset, bijv. de URI of een andere unieke identificatie in de context van het Catalogus."
       }
     },
     {
       "field_name": "issued",
       "label": {
-        "en": "Issued"
+        "en": "Issued",
+        "nl": "Uitgegeven"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:issued] This property contains the date of formal issuance (e.g., publication) of the Dataset."
+        "en": "[dct:issued] This property contains the date of formal issuance (e.g., publication) of the Dataset.",
+        "nl": "[dct:issued] Deze eigenschap bevat de datum van formele uitgave (bijv. publicatie) van de Dataset."
       },
       "preset": "date"
     },
     {
       "field_name": "language",
       "label": {
-        "en": "Language"
+        "en": "Language",
+        "nl": "Taal"
       },
       "preset": "multiple_text",
       "help_inline": true,
       "help_text": {
-        "en": "[dct:language] This property refers to a language of the Dataset. This property can be repeated if there are multiple languages in the Dataset."
+        "en": "[dct:language] This property refers to a language of the Dataset. This property can be repeated if there are multiple languages in the Dataset.",
+        "nl": "[dct:language] Deze eigenschap verwijst naar een taal van de Dataset. Deze eigenschap kan worden herhaald als er meerdere talen in de Dataset aanwezig zijn."
       }
     },
     {
       "field_name": "modified",
       "label": {
-        "en": "Modification Date"
+        "en": "Modification Date",
+        "nl": "Datum Wijziging"
       },
       "preset": "date",
       "help_inline": true,
       "help_text": {
-        "en": "[dct:modified] This property contains the most recent date on which the Dataset was changed or modified."
+        "en": "[dct:modified] This property contains the most recent date on which the Dataset was changed or modified.",
+        "nl": "[dct:modified] Deze eigenschap bevat de meest recente datum waarop de Dataset is gewijzigd of gewijzigd."
       }
     },
     {
       "field_name": "provenance",
       "label": {
-        "en": "Provenance"
+        "en": "Provenance",
+        "nl": "Afkomst"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:provenance] This property contains a statement about the lineage of a Dataset."
+        "en": "[dct:provenance] This property contains a statement about the lineage of a Dataset.",
+        "nl": "[dct:provenance] Deze eigenschap bevat een verklaring over de afkomst van een Dataset, alle wijzigingen in eigendom en bewaring van een dataset sinds de creatie ervan, die van belang zijn voor de authenticiteit, integriteit en interpretatie ervan.."
       }
     },
     {
       "field_name": "relation",
       "label": {
-        "en": "Relation"
+        "en": "Relation",
+        "nl": "Relatie"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:relation] This property refers to a related resource."
+        "en": "[dct:relation] This property refers to a related resource.",
+        "nl": "[dct:relation] Deze eigenschap verwijst naar een gerelateerde bron."
       }
     },
     {
       "field_name": "sample",
       "label": {
-        "en": "Sample"
+        "en": "Sample",
+        "nl": "Voorbeeld"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[adms:sample] This property refers to a sample distribution of the dataset."
+        "en": "[adms:sample] This property refers to a sample distribution of the dataset.",
+        "nl": "[adms:sample] Deze eigenschap verwijst naar een voorbeeld Distributie van de dataset."
       }
     },
     {
       "field_name": "source",
       "label": {
-        "en": "Source"
+        "en": "Source",
+        "nl": "Bron"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:source] This property refers to a related Dataset from which the described Dataset is derived."
+        "en": "[dct:source] This property refers to a related Dataset from which the described Dataset is derived.",
+        "nl": "[dct:source] Deze eigenschap verwijst naar een gerelateerde Dataset waarvan de beschreven Dataset is afgeleid."
       }
     },
     {
       "field_name": "dcat_type",
       "label": {
-        "en": "Type"
+        "en": "Type",
+        "nl": "Type"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:type] This property refers to the type of the Dataset."
+        "en": "[dct:type] This property refers to the type of the Dataset.",
+        "nl": "[dct:type] Deze eigenschap verwijst naar het type van de Dataset."
       }
     },
     {
       "field_name": "has_version",
       "label": {
-        "en": "Has Version"
+        "en": "Has Version",
+        "nl": "Bevat Versie"
       },
       "preset": "multiple_text",
       "help_inline": true,
       "help_text": {
-        "en": "[dct:hasVersion] This property refers to a related Dataset that is a version, edition, or adaptation of the described Dataset."
+        "en": "[dct:hasVersion] This property refers to a related Dataset that is a version, edition, or adaptation of the described Dataset.",
+        "nl": "[dct:hasVersion] Deze eigenschap verwijst naar een gerelateerde Dataset die een versie, editie of aanpassing is van de beschreven Dataset."
       }
     },
     {
       "field_name": "documentation",
       "label": {
-        "en": "Documentation"
+        "en": "Documentation",
+        "nl": "Documentatie"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[foaf:page] This property refers to a page or document about this Dataset."
+        "en": "[foaf:page] This property refers to a page or document about this Dataset.",
+        "nl": "[foaf:page] Deze eigenschap verwijst naar een pagina of document over deze Dataset."
       }
     },
     {
       "field_name": "qualified_attribution",
       "label": {
-        "en": "Qualified Attribution"
+        "en": "Qualified Attribution",
+        "nl": "Gekwalificeerde Toeschrijving"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[prov:qualifiedAttribution ] This property refers to a link to an Agent having some form of responsibility for the resource."
+        "en": "[prov:qualifiedAttribution ] This property refers to a link to an Agent having some form of responsibility for the resource.",
+        "nl": "[prov:qualifiedAttribution] Deze eigenschap verwijst naar een link naar een Agent die op een bepaalde wijze verantwoordelijk is voor de bron."
       }
     },
     {
       "field_name": "was_generated_by",
       "label": {
-        "en": "Was Generated By"
+        "en": "Was Generated By",
+        "nl": "Was Gegenereerd Door"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[prov:wasGeneratedBy] This property refers to an activity that generated, or provides the business context for, the creation of the dataset."
+        "en": "[prov:wasGeneratedBy] This property refers to an activity that generated, or provides the business context for, the creation of the dataset.",
+        "nl": "[prov:wasGeneratedBy] Deze eigenschap verwijst naar een activiteit waarbij de dataset is gegenereerd of de zakelijke context biedt voor de creatie van de dataset."
       }
     },
     {
       "field_name": "alternate_identifier",
       "label": {
-        "en": "Alternate identifier"
+        "en": "Alternate identifier",
+        "nl": "Alternatieve identificatie"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[adms:identifier] This property refers to a secondary identifier of the Dataset, such as MAST/ADS , DataCite , DOI , EZID  or W3ID ."
+        "en": "[adms:identifier] This property refers to a secondary identifier of the Dataset, such as MAST/ADS , DataCite , DOI , EZID  or W3ID .",
+        "nl": "[adms:identifier] Deze eigenschap verwijst naar een secundaire identificatie van de Dataset, zoals MAST/ADS, DataCite, DOI, EZID of W3ID."
       }
     }
   ],
@@ -538,7 +631,8 @@
       "label": "Name",
       "help_inline": true,
       "help_text": {
-        "en": "[dct:title] This property contains a name given to the Distribution."
+        "en": "[dct:title] This property contains a name given to the Distribution.",
+        "nl": "[dct:title] Deze eigenschap bevat een naam voor de Distribution."
       },
       "form_placeholder": "eg. January 2011 Gold Prices"
     },
@@ -549,7 +643,8 @@
       "form_placeholder": "Some useful notes about the data",
       "help_inline": true,
       "help_text": {
-        "en": "[dct:description] This property contains a free-text account of the Distribution."
+        "en": "[dct:description] This property contains a free-text account of the Distribution.",
+        "nl": "[dct:description] Deze eigenschap bevat een vrije tekstbeschrijving van de Distribution."
       }
     },
     {
@@ -558,47 +653,56 @@
       "preset": "resource_format_autocomplete",
       "help_inline": true,
       "help_text": {
-        "en": "[dct:format] This property refers to the file format of the Distribution."
+        "en": "[dct:format] This property refers to the file format of the Distribution.",
+        "nl": "[dct:format] Deze eigenschap verwijst naar het bestandsformaat van de Distribution."
       }
     },
     {
       "field_name": "access_url",
       "label": {
-        "en": "Access URL"
+        "en": "Access URL",
+        "nl": "Toegangs-URL"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dcat:accessURL] This property contains a URL that gives access to a Distribution of the Dataset. The resource at the access URL may contain information about how to get the Dataset."
+        "en": "[dcat:accessURL] This property contains a URL that gives access to a Distribution of the Dataset. The resource at the access URL may contain information about how to get the Dataset.",
+        "nl": "[dcat:accessURL] Deze eigenschap bevat een URL die toegang biedt tot een Distribution van de Dataset. De bron op de toegangs-URL kan informatie bevatten over hoe u toegang kunt krijgen tot de Dataset."
       }
     },
     {
       "field_name": "availability",
       "label": {
-        "en": "Availability"
+        "en": "Availability",
+        "nl": "Beschikbaarheid"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dcatap:availability] This property indicates how long it is planned to keep the Distribution of the Dataset available. "
+        "en": "[dcatap:availability] This property indicates how long it is planned to keep the Distribution of the Dataset available. ",
+        "nl": "[dcatap:availability] Deze eigenschap geeft aan hoe lang het is gepland om de Distribution van de Dataset beschikbaar te houden."
       }
     },
     {
       "field_name": "status",
       "label": {
-        "en": "Status"
+        "en": "Status",
+        "nl": "Status"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[adms:status] The status of the distribution in the context of maturity lifecycle."
+        "en": "[adms:status] The status of the distribution in the context of maturity lifecycle.",
+        "nl": "[adms:status] De status van de distribution in de context van de maturiteitslevenscyclus."
       }
     },
     {
       "field_name": "access_services",
       "label": {
-        "en": "Access Services"
+        "en": "Access Services",
+        "nl": "Toegangsservices"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dcat:accessService] This property refers to a data service that gives access to the distribution of the dataset."
+        "en": "[dcat:accessService] This property refers to a data service that gives access to the distribution of the dataset.",
+        "nl": "[dcat:accessService] Deze eigenschap verwijst naar een dataservice die toegang biedt tot de distribution van de dataset."
       }
     },
     {
@@ -609,11 +713,13 @@
     {
       "field_name": "compress_format",
       "label": {
-        "en": "Compress Format"
+        "en": "Compress Format",
+        "nl": "Compressieformaat"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dcat:compressFormat] This property refers to the format of the file in which the data is contained in a compressed form, e.g. to reduce the size of the downloadable file."
+        "en": "[dcat:compressFormat] This property refers to the format of the file in which the data is contained in a compressed form, e.g. to reduce the size of the downloadable file.",
+        "nl": "[dcat:compressFormat] Deze eigenschap verwijst naar het bestandsformaat waarin de gegevens in een gecomprimeerde vorm zijn opgenomen, bijv. om de grootte van het downloadbare bestand te verkleinen."
       }
     },
     {
@@ -622,7 +728,8 @@
       "display_snippet": "link.html",
       "help_inline": true,
       "help_text": {
-        "en": "[dcat:downloadURL] This property contains a URL that is a direct link to a downloadable file in a given format."
+        "en": "[dcat:downloadURL] This property contains a URL that is a direct link to a downloadable file in a given format.",
+        "nl": "[dcat:downloadURL] Deze eigenschap bevat een URL die een directe link is naar een downloadbaar bestand in een bepaald formaat."
       }
     },
     {
@@ -630,109 +737,130 @@
       "label": "Mime Type",
       "help_inline": true,
       "help_text": {
-        "en": "[dcat:mediaType] This property refers to the media type of the Distribution as defined in the official register of media types managed by IANA."
+        "en": "[dcat:mediaType] This property refers to the media type of the Distribution as defined in the official register of media types managed by IANA.",
+        "nl": "[dcat:mediaType] Deze eigenschap verwijst naar het mediatype van de Distribution zoals gedefinieerd in het officiële register van mediatypes beheerd door IANA."
       }
     },
     {
       "field_name": "package_format",
       "label": {
-        "en": "Package Format"
+        "en": "Package Format",
+        "nl": "Pakketformaat"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dcat:packageFormat] This property refers to the format of the file in which one or more data files are grouped together, e.g. to enable a set of related files to be downloaded together."
+        "en": "[dcat:packageFormat] This property refers to the format of the file in which one or more data files are grouped together, e.g. to enable a set of related files to be downloaded together.",
+        "nl": "[dcat:packageFormat] Deze eigenschap verwijst naar het bestandsformaat waarin een of meer gegevensbestanden zijn gegroepeerd, bijv. om een set gerelateerde bestanden samen te kunnen downloaden."
       }
     },
     {
       "field_name": "spatial_resolution_in_meters",
       "label": {
-        "en": "Spatial Resolution in Meters"
+        "en": "Spatial Resolution in Meters",
+        "nl": "Spatiële Resolutie in meters"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dcat:spatialResolutionInMeters] This property refers to the minimum spatial separation resolvable in a dataset, measured in meters."
+        "en": "[dcat:spatialResolutionInMeters] This property refers to the minimum spatial separation resolvable in a dataset, measured in meters.",
+        "nl": "[dcat:spatialResolutionInMeters] Deze eigenschap verwijst naar de meest precieze ruimtelijke resolutie in de dataset, gemeten in meters."
       }
     },
     {
       "field_name": "temporal_resolution",
       "label": {
-        "en": "Temporal Resolution"
+        "en": "Temporal Resolution",
+        "nl": "Tijdsresolutie"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dcat:temporalResolution] This property refers to the minimum time period resolvable in the dataset."
+        "en": "[dcat:temporalResolution] This property refers to the minimum time period resolvable in the dataset.",
+        "nl": "[dcat:temporalResolution] Deze eigenschap verwijst naar de minimale tijdsperiode die in de dataset kan worden opgelost."
       }
     },
     {
       "field_name": "conforms_to",
       "label": {
-        "en": "Conforms to"
+        "en": "Conforms to",
+        "nl": "Voldoet aan"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:conformsTo] This property refers to an implementing rule or other specification."
+        "en": "[dct:conformsTo] This property refers to an implementing rule or other specification.",
+        "nl": "[dct:conformsTo] Deze eigenschap verwijst naar een uitvoerende regel of andere specificatie."
       }
     },
     {
       "field_name": "issued",
       "label": {
-        "en": "Issued"
+        "en": "Issued",
+        "nl": "Uitgegeven"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:issued] This property contains the date of formal issuance (e.g., publication) of the Dataset."
+        "en": "[dct:issued] This property contains the date of formal issuance (e.g., publication) of the Dataset.",
+        "nl": "[dct:issued] Deze eigenschap bevat de datum van formele uitgave (bijv. publicatie) van de Dataset."
       },
       "preset": "date"
     },
     {
       "field_name": "language",
       "label": {
-        "en": "Language"
+        "en": "Language",
+        "nl": "Taal"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:language] This property refers to a language of the Dataset. This property can be repeated if there are multiple languages in the Dataset."
+        "en": "[dct:language] This property refers to a language of the Dataset. This property can be repeated if there are multiple languages in the Dataset.",
+        "nl": "[dct:language] Deze eigenschap verwijst naar een taal van de Dataset. Deze eigenschap kan worden herhaald als er meerdere talen in de Dataset aanwezig zijn."
       }
     },
     {
       "field_name": "modified",
       "label": {
-        "en": "Modification Date"
+        "en": "Modification Date",
+        "nl": "Datum Wijziging"
       },
       "preset": "date",
       "help_inline": true,
       "help_text": {
-        "en": "[dct:modified] This property contains the most recent date on which the Dataset was changed or modified."
+        "en": "[dct:modified] This property contains the most recent date on which the Dataset was changed or modified.",
+        "nl": "[dct:modified] Deze eigenschap bevat de meest recente datum waarop de Dataset is gewijzigd of gewijzigd."
       }
     },
     {
       "field_name": "rights",
       "label": {
-        "en": "Rights"
+        "en": "Rights",
+        "nl": "Rechten"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[dct:rights] This property refers to a statement that specifies rights associated with the Distribution."
+        "en": "[dct:rights] This property refers to a statement that specifies rights associated with the Distribution.",
+        "nl": "[dct:rights] Deze eigenschap verwijst naar een verklaring die de rechten aangeeft die zijn gekoppeld aan de Distribution."
       }
     },
     {
       "field_name": "documentation",
       "label": {
-        "en": "Documentation"
+        "en": "Documentation",
+        "nl": "Documentatie"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[foaf:page] This property refers to a page or document about this Distribution."
+        "en": "[foaf:page] This property refers to a page or document about this Distribution.",
+        "nl": "[foaf:page] Deze eigenschap verwijst naar een pagina of document over deze Distribution."
       }
     },
     {
       "field_name": "has_policy",
       "label": {
-        "en": "Has Policy"
+        "en": "Has Policy",
+        "nl": "Heeft Beleid"
       },
       "help_inline": true,
       "help_text": {
-        "en": "[odrl:hasPolicy] This property refers to the policy expressing the rights associated with the distribution if using the ODRL vocabulary."
+        "en": "[odrl:hasPolicy] This property refers to the policy expressing the rights associated with the distribution if using the ODRL vocabulary.",
+        "nl": "[odrl:hasPolicy] Deze eigenschap verwijst naar het beleid dat de rechten aangeeft die zijn gekoppeld aan de distribution als de ODRL-vocabulaire wordt gebruikt."
       }
     },
     {
@@ -740,7 +868,8 @@
       "label": "Hash",
       "help_inline": true,
       "help_text": {
-        "en": "[spdx:checksumValue] This property provides a lower case hexadecimal encoded digest value produced using a specific algorithm."
+        "en": "[spdx:checksumValue] This property provides a lower case hexadecimal encoded digest value produced using a specific algorithm.",
+        "nl": "[spdx:checksumValue] Deze eigenschap biedt een kleine hexadecimale hashwaarde die is gegenereerd met behulp van een specifiek algoritme."
       }
     },
     {
@@ -748,7 +877,8 @@
       "label": "Hash Algorithm",
       "help_inline": true,
       "help_text": {
-        "en": "[spdx:algorithm] This property identifies the algorithm used to produce the subject Checksum. "
+        "en": "[spdx:algorithm] This property identifies the algorithm used to produce the subject Checksum. ",
+        "nl": "[spdx:algorithm] Deze eigenschap identificeert het algoritme dat is gebruikt om de Checksum te produceren."
       }
     }
   ]


### PR DESCRIPTION
This PR adds Dutch translation to all scheming fields.

Hopefully will also translate the search facets when we run CKAN with Dutch locale.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce Dutch translations for all fields in the scheming schema to support multilingual capabilities, potentially improving user experience for Dutch-speaking users.

New Features:
- Add Dutch translations to all fields in the scheming schema, enhancing multilingual support.

<!-- Generated by sourcery-ai[bot]: end summary -->