### PR TITLE
feat(auth): remove Keycloak integration from CKAN and user portal

### DIFF
--- a/ckanext/gdi_userportal/templates/header.html
+++ b/ckanext/gdi_userportal/templates/header.html
@@ -59,7 +59,7 @@ SPDX-License-Identifier: Apache-2.0
         {% block header_account_notlogged %}
         <li>
           <a href="{{ h.url_for('user.login') }}" title="{{ _('Log in') }}">
-            <i class="fa fa-sign" aria-hidden="true"></i>
+            <i class="fa fa-sign-in" aria-hidden="true"></i>
             <span class="text">{{ _('Log in') }}</span>
           </a>
         </li>

--- a/ckanext/gdi_userportal/templates/header.html
+++ b/ckanext/gdi_userportal/templates/header.html
@@ -57,10 +57,12 @@ SPDX-License-Identifier: Apache-2.0
     <nav class="account not-authed" aria-label="{{ _('Account') }}">
       <ul class="list-unstyled">
         {% block header_account_notlogged %}
-        <li><a href="/user/login/oidc-pkce" title="{{ _('Log in') }}">
-          <i class="fa fa-sign-in" aria-hidden="true"></i>
-          <span class="text">{{ _('Log in') }}</span>
-        </a></li>
+        <li>
+          <a href="{{ h.url_for('user.login') }}" title="{{ _('Log in') }}">
+            <i class="fa fa-sign" aria-hidden="true"></i>
+            <span class="text">{{ _('Log in') }}</span>
+          </a>
+        </li>
         {% endblock %}
       </ul>
     </nav>


### PR DESCRIPTION
- Disabled Keycloak in user portal extension

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Remove Keycloak integration from the CKAN user portal by updating the login link to use the default user login route instead of the OIDC PKCE route.

<!-- Generated by sourcery-ai[bot]: end summary -->