### PR TITLE
fix(translations): populate translations with a fallback language

### DIFF
--- a/ckanext/gdi_userportal/logic/action/translation_utils.py
+++ b/ckanext/gdi_userportal/logic/action/translation_utils.py
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
@@ -12,8 +11,6 @@ from ckan.common import config, request
 
 # -*- coding: utf-8 -*-
 from ckan.plugins import toolkit
-
-log = logging.getLogger(__name__)
 
 PACKAGE_REPLACE_FIELDS = [
     "access_rights",


### PR DESCRIPTION
Currently when querying a specific language through the API, it will only return labels for that language. This PR adds a fallback language (can be configured, but default is English). First all translations from the fallback language will be put in the translation dictionary, then they will be overriden by the preferred language if they exist.

Fixes [SRP-793](https://health-ri.atlassian.net/jira/software/c/projects/SRP/boards/5?selectedIssue=SRP-793)

## Summary by Sourcery

Add a fallback language mechanism to the translation utility, ensuring that labels are populated with a default language if the preferred language is unavailable. This change addresses translation gaps by first populating translations with the fallback language and then overriding them with the preferred language if available.

Bug Fixes:
- Implement a fallback language mechanism for translations to ensure labels are populated even if the preferred language is unavailable.

Enhancements:
- Refactor the translation utility to use a configurable fallback language, defaulting to English, for better flexibility.