### PR TITLE
Revert trivy update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: "${{ steps.tag.outputs.last_tag }}"
           format: "table"

--- a/ckanext/gdi_userportal/scheming/schemas/gdi_userportal.yaml
+++ b/ckanext/gdi_userportal/scheming/schemas/gdi_userportal.yaml
@@ -56,35 +56,6 @@ dataset_fields:
     nl: "[dct:temporal] Deze eigenschap verwijst naar een tijdsperiode die door de Dataset wordt gedekt."
   preset: datetime_flex
 
-- field_name: creator
-  label: Creator
-  repeating_subfields:
-    - field_name: uri
-      label: Creator URI
-
-    - field_name: name
-      label: Creator Name
-
-    - field_name: email
-      label: Creator Email
-      display_snippet: email.html
-
-    - field_name: url
-      label: Creator URL
-      display_snippet: link.html
-
-    - field_name: type
-      label: Creator Type
-
-    - field_name: identifier
-      label: Creator Identifier
-      help_text:
-        en: Unique identifier for the creator, such as a ROR ID.
-        nl: Unieke identificatie voor de maker, zoals een ROR-ID.
-  help_text:
-    en: Entity responsible for producing the dataset.
-    nl: Entiteit die verantwoordelijk is voor het produceren van de dataset.
-
 resource_fields:
 - field_name: issued
   label:


### PR DESCRIPTION
Update breaks Trivy scanner

## Summary by Sourcery

CI:
- Revert Trivy action version from 0.29.0 to 0.28.0 in GitHub Actions workflow.