### PR TITLE
fix(Dockerfile): use COPY instead of ADD for secure file handling

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -16,7 +16,7 @@ USER root
 RUN cp -R $SOLR_CONFIG_DIR/_default $SOLR_CONFIG_DIR/ckan
 
 # Update the schema
-ADD ./schema.xml $SOLR_SCHEMA_FILE
+COPY ./schema.xml $SOLR_SCHEMA_FILE
 RUN chmod 644 $SOLR_SCHEMA_FILE 
 
 USER solr


### PR DESCRIPTION
Replaced ADD with COPY to align with Dockerfile best practices, ensuring explicit and secure file copying. Addresses issue #129 by preventing unintended behaviors such as remote URL downloads or archive extraction.

## Summary by Sourcery

Bug Fixes:
- Replace ADD with COPY in Dockerfile to prevent unintended behaviors such as remote URL downloads or archive extraction.