### PR TITLE
feat(ART-11313): add s3 harvester

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           pip install -r requirements.txt
           pip install -r dev-requirements.txt
           pip install --upgrade pytest-rerunfailures
-          pip install -e 'git+https://github.com/CivityNL/ckanext-scheming.git@release-3.0.0-civity#egg=ckanext-scheming[requirements]'
+          pip install -e 'git+https://github.com/CivityNL/ckanext-scheming.git@3.0.0-civity-1#egg=ckanext-scheming[requirements]'
           pip install -e 'git+https://github.com/ckan/ckanext-harvest.git@v1.6.0#egg=ckanext-harvest[requirements]'
           pip install -e 'git+https://github.com/ckan/ckanext-dcat.git@v2.1.0#egg=ckanext-dcat[requirements]'
           pip install -r https://raw.githubusercontent.com/ckan/ckanext-dcat/v2.1.0/requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
           pip install -e 'git+https://github.com/ckan/ckanext-harvest.git@v1.6.0#egg=ckanext-harvest[requirements]'
           pip install -e 'git+https://github.com/ckan/ckanext-dcat.git@v2.1.0#egg=ckanext-dcat[requirements]'
           pip install -r https://raw.githubusercontent.com/ckan/ckanext-dcat/v2.1.0/requirements.txt
+          pip install -r https://raw.githubusercontent.com/ckan/ckanext-harvest/v1.6.0/requirements.txt
           python3 setup.py develop
       - name: Setup extension
         run: |

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Add a new ckan.ini in your local repository and add the below values:
 
 ## Configure User login
 
-     ckan sysadmin add <username> 
+     ckan sysadmin add <username>    # Replace <username> with the actual username you want to create
 
 ## DB Set UP
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,51 @@ do:
     python setup.py develop
     pip install -r dev-requirements.txt
 
+Add needed docker images:
+    
+Postgres:
 
+    docker run -d \                                                      
+      --name ckan-postgres \
+      -e POSTGRES_USER=ckan_default \
+      -e POSTGRES_PASSWORD=password \
+      -e POSTGRES_DB=ckan_default \
+      -v /path/to/your/data:/var/lib/postgresql/data \
+      -p 5432:5432 \
+      postgres
+
+Solr:
+
+     docker run --name ckan-solr -p 8983:8983 -d ckan/ckan-solr:2.10-solr9
+
+Redis:
+
+     docker run --name ckan-redis -p 6379:6379 -d redis:7
+
+Add a new ckan.ini in your local repository and add the below values:
+
+     sqlalchemy.url = postgresql://ckan_default:password@localhost:5432/ckan_default
+     ckanext.dcat.rdf.profiles = euro_dcat_ap
+     ckan.harvest.s3_rdf.aws_access_key = changeme
+     ckan.harvest.s3_rdf.aws_secret_key = changeme
+
+## Configure User login
+
+     ckan sysadmin add <username> 
+
+## DB Set UP
+
+To initialize local db:
+
+     ckan db init
+
+To initialize db with harvester tables:
+
+     ckan db upgrade -p harvest
+
+To clean the db:
+
+     ckan db clean
 ## Tests
 
 To run the tests, do:

--- a/ckanext/gdi_userportal/harvesters/__init__.py
+++ b/ckanext/gdi_userportal/harvesters/__init__.py
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2025 PNED G.I.E.
+# SPDX-FileCopyrightText: 2024 PNED G.I.E.
 #
-# SPDX-License-Identifier: AGPL-3.0-only
+# SPDX-License-Identifier: Apache-2.0
 
 from ckanext.gdi_userportal.harvesters.s3rdfharvester import S3RDFHarvester

--- a/ckanext/gdi_userportal/harvesters/__init__.py
+++ b/ckanext/gdi_userportal/harvesters/__init__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ckanext.gdi_userportal.harvesters.s3rdfharvester import S3RDFHarvester
+from ckanext.gdi_userportal.harvesters.s3_rdf_harvester import S3RDFHarvester

--- a/ckanext/gdi_userportal/harvesters/__init__.py
+++ b/ckanext/gdi_userportal/harvesters/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Civity
-# SPDX-FileContributor: 2024 Stichting Health-RI
+# SPDX-FileCopyrightText: 2025 PNED G.I.E.
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/ckanext/gdi_userportal/harvesters/__init__.py
+++ b/ckanext/gdi_userportal/harvesters/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Civity
+# SPDX-FileContributor: 2024 Stichting Health-RI
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from ckanext.gdi_userportal.harvesters.s3rdfharvester import S3RDFHarvester

--- a/ckanext/gdi_userportal/harvesters/s3_rdf_harvester.py
+++ b/ckanext/gdi_userportal/harvesters/s3_rdf_harvester.py
@@ -7,6 +7,7 @@ import json
 import logging
 from urllib.parse import urlparse
 
+import botocore
 import ckan.model as model
 from ckanext.harvest.model import HarvestObject, HarvestSource
 from ckan.plugins.toolkit import config

--- a/ckanext/gdi_userportal/harvesters/s3rdfharvester.py
+++ b/ckanext/gdi_userportal/harvesters/s3rdfharvester.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Civity
-# SPDX-FileContributor: 2024 Stichting Health-RI
+# SPDX-FileCopyrightText: 2025 PNED G.I.E.
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/ckanext/gdi_userportal/harvesters/s3rdfharvester.py
+++ b/ckanext/gdi_userportal/harvesters/s3rdfharvester.py
@@ -1,6 +1,6 @@
-# SPDX-FileCopyrightText: 2025 PNED G.I.E.
+# SPDX-FileCopyrightText: 2024 PNED G.I.E.
 #
-# SPDX-License-Identifier: AGPL-3.0-only
+# SPDX-License-Identifier: Apache-2.0
 
 import boto3
 import json
@@ -19,9 +19,9 @@ class S3RDFHarvester(DCATRDFHarvester):
 
     def info(self):
         return {
-            'name': 's3_rdf',
-            'title': 'S3 RDF Harvester',
-            'description': 'Harvests RDF files from an S3 bucket.'
+            'name': 's3_dcat_rdf',
+            'title': 'S3 DCAT RDF Harvester',
+            'description': 'Harvests RDF files with DCAT datasets from an S3 bucket.'
         }
 
     def gather_stage(self, harvest_job):
@@ -89,8 +89,25 @@ class S3RDFHarvester(DCATRDFHarvester):
 
             return object_ids
 
+        except botocore.exceptions.ClientError as e:
+            error_code = e.response['Error']['Code']
+            error_message = e.response['Error']['Message']
+            self._save_gather_error(
+                f'AWS Client Error accessing S3 bucket: {error_code} - {error_message}',
+                harvest_job
+            )
+            return []
+        except botocore.exceptions.BotoCoreError as e:
+            self._save_gather_error(
+                f'AWS BotoCore Error accessing S3 bucket: {str(e)}',
+                harvest_job
+            )
+            return []
         except Exception as e:
-            self._save_gather_error(f'Error accessing S3 bucket: {e}', harvest_job)
+            self._save_gather_error(
+                f'Unexpected error accessing S3 bucket: {str(e)}',
+                harvest_job
+            )
             return []
 
     def _get_s3_client_info(self, harvest_job):

--- a/ckanext/gdi_userportal/harvesters/s3rdfharvester.py
+++ b/ckanext/gdi_userportal/harvesters/s3rdfharvester.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2023 Civity
+# SPDX-FileContributor: 2024 Stichting Health-RI
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import boto3
+import json
+import logging
+from urllib.parse import urlparse
+
+import ckan.model as model
+from ckanext.harvest.model import HarvestObject, HarvestSource
+from ckan.plugins.toolkit import config
+from ckanext.dcat.processors import RDFParserException, RDFParser
+from ckanext.dcat.harvesters.rdf import DCATRDFHarvester
+
+log = logging.getLogger(__name__)
+
+class S3RDFHarvester(DCATRDFHarvester):
+
+    def info(self):
+        return {
+            'name': 's3_rdf',
+            'title': 'S3 RDF Harvester',
+            'description': 'Harvests RDF files from an S3 bucket.'
+        }
+
+    def gather_stage(self, harvest_job):
+        log.info('In S3RDFHarvester gather_stage')
+
+        bucket_name, s3 = self._get_s3_client_info(harvest_job)
+        rdf_format = None
+        if harvest_job.source.config:
+            rdf_format = json.loads(harvest_job.source.config).get("rdf_format")
+
+        try:
+            # List objects in the S3 bucket
+            s3_objects = s3.list_objects_v2(Bucket=bucket_name)
+            if 'Contents' not in s3_objects:
+                self._save_gather_error('No objects found in the S3 bucket', harvest_job)
+                return []
+            guids_in_source = []
+            object_ids = []
+            self._names_taken = []
+
+            for obj in s3_objects['Contents']:
+                key = obj['Key']
+                if not (key.endswith('.rdf') | key.endswith('.ttl')):
+                    continue
+                # Download the object from S3
+                s3_object = s3.get_object(Bucket=bucket_name, Key=key)
+                content = s3_object['Body'].read().decode('utf-8')
+                parser = RDFParser()
+                try:
+                    parser.parse(content, _format=rdf_format)
+                except RDFParserException as e:
+                    self._save_gather_error(f'Error parsing the RDF file {key}: {e}', harvest_job)
+                    continue
+
+                source_dataset = model.Package.get(harvest_job.source.id)
+
+                for dataset in parser.datasets():
+                    if not dataset.get('name'):
+                        dataset['name'] = self._gen_new_name(dataset['title'])
+                    if dataset['name'] in self._names_taken:
+                        suffix = len([i for i in self._names_taken if i.startswith(dataset['name'] + '-')]) + 1
+                        dataset['name'] = f"{dataset['name']}-{suffix}"
+                    self._names_taken.append(dataset['name'])
+
+                    if not dataset.get('owner_org') and source_dataset.owner_org:
+                        dataset['owner_org'] = source_dataset.owner_org
+
+                    guid = self._get_guid(dataset, source_url=source_dataset.url)
+
+                    if not guid:
+                        self._save_gather_error(f'Could not get a unique identifier for dataset: {dataset}', harvest_job)
+                        continue
+
+                    dataset['extras'].append({'key': 'guid', 'value': guid})
+                    guids_in_source.append(guid)
+
+                    obj = HarvestObject(guid=guid, job=harvest_job,
+                                        content=json.dumps(dataset))
+
+                    obj.save()
+                    object_ids.append(obj.id)
+
+            object_ids_to_delete = self._mark_datasets_for_deletion(guids_in_source, harvest_job)
+            object_ids.extend(object_ids_to_delete)
+
+            return object_ids
+
+        except Exception as e:
+            self._save_gather_error(f'Error accessing S3 bucket: {e}', harvest_job)
+            return []
+
+    def _get_s3_client_info(self, harvest_job):
+        # Load S3 configuration
+        aws_access_key = config.get('ckan.harvest.s3_rdf.aws_access_key')
+        aws_secret_key = config.get('ckan.harvest.s3_rdf.aws_secret_key')
+        harvest_source = HarvestSource.get(harvest_job.source_id, attr="id")
+        parsed_url = urlparse(harvest_source.url)
+        endpoint = f"{parsed_url.scheme}://{parsed_url.netloc}"  # Scheme + Host
+        path_parts = parsed_url.path.strip("/").split("/")  # Split the path
+        bucket_name = path_parts[0] if path_parts else None  # First part of the path
+        # Initialize S3 client with authentication
+        s3 = boto3.client(
+            's3',
+            endpoint_url=endpoint,
+            aws_access_key_id=aws_access_key,
+            aws_secret_access_key=aws_secret_key
+        )
+        return bucket_name, s3
+
+    def fetch_stage(self, harvest_object):
+        return super(S3RDFHarvester, self).fetch_stage(harvest_object)
+
+    def import_stage(self, harvest_object):
+        return super(S3RDFHarvester, self).import_stage(harvest_object)
+
+    def _create_or_update_package(self, dataset_dict, harvest_object):
+        return super(S3RDFHarvester, self)._create_or_update_package(dataset_dict, harvest_object)
+
+    def _create_package(self, dataset_dict):
+        return super(S3RDFHarvester, self)._create_package(dataset_dict)
+
+    def _update_package(self, dataset_dict):
+        return super(S3RDFHarvester, self)._update_package(dataset_dict)
+
+    def _save_package(self, dataset_dict, action):
+        return super(S3RDFHarvester, self)._save_package(dataset_dict, action)

--- a/ckanext/gdi_userportal/tests/test_harvester.py
+++ b/ckanext/gdi_userportal/tests/test_harvester.py
@@ -1,10 +1,13 @@
+# SPDX-FileCopyrightText: 2024 PNED G.I.E.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import pytest
 from unittest.mock import patch, MagicMock
 from botocore.exceptions import ClientError, BotoCoreError
 from ckan.plugins.toolkit import config
 from ckanext.dcat.processors import RDFParserException
-from ckanext.harvest.model import HarvestObject, HarvestJob, HarvestSource
 
 from ckanext.gdi_userportal.harvesters import S3RDFHarvester
 

--- a/ckanext/gdi_userportal/tests/test_harvester.py
+++ b/ckanext/gdi_userportal/tests/test_harvester.py
@@ -1,0 +1,317 @@
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+from botocore.exceptions import ClientError, BotoCoreError
+from ckan.plugins.toolkit import config
+from ckanext.dcat.processors import RDFParserException
+from ckanext.harvest.model import HarvestObject, HarvestJob, HarvestSource
+
+from ckanext.gdi_userportal.harvesters import S3RDFHarvester
+
+
+@pytest.fixture
+def mock_harvest_source():
+    class MockSource:
+        id = "test-harvest-source-id"
+        url = "s3://my-endpoint/my-bucket"
+        config = None
+        owner_org = None
+    return MockSource()
+
+@pytest.fixture
+def mock_harvest_job(mock_harvest_source):
+
+    class MockJob:
+        id = "test-harvest-job-id"
+        source_id = mock_harvest_source.id
+        source = mock_harvest_source
+    return MockJob()
+
+@pytest.fixture
+def s3_rdf_harvester():
+    return S3RDFHarvester()
+
+
+@pytest.fixture
+def mock_harvestobject_patch():
+
+    with patch("ckanext.gdi_userportal.harvesters.s3_rdf_harvester.HarvestObject") as ho_cls:
+        created_object_ids = []
+        def side_effect_constructor(**kwargs):
+            new_id = f"harvest-obj-{len(created_object_ids)+1}"
+            ho_mock = MagicMock()
+            ho_mock.id = new_id
+            ho_mock.save = MagicMock()
+            ho_mock.content = kwargs.get('content', None)
+            created_object_ids.append(new_id)
+            return ho_mock
+
+        ho_cls.side_effect = side_effect_constructor
+
+        def side_effect_get(obj_id):
+            get_mock = MagicMock()
+            get_mock.id = obj_id
+            get_mock.content = '{"title": "Dummy fetched content"}'
+            return get_mock
+        ho_cls.get.side_effect = side_effect_get
+
+        yield created_object_ids
+
+@pytest.fixture
+def mock_harvestsource_patch():
+    with patch("ckanext.harvest.model.HarvestSource.get") as hs_get:
+        mock_source_package = MagicMock()
+        mock_source_package.owner_org = "org-id"
+        hs_get.return_value = mock_source_package
+        yield
+
+@pytest.fixture
+def mock_mark_deletion_patch():
+    with patch.object(S3RDFHarvester, "_mark_datasets_for_deletion", return_value=[]):
+        yield
+
+@pytest.fixture
+def mock_save_gather_error_patch():
+    with patch.object(S3RDFHarvester, "_save_gather_error") as mock_save:
+        yield mock_save
+
+
+class TestS3RDFHarvesterGatherStage:
+
+    @pytest.mark.usefixtures("mock_harvestobject_patch",
+                             "mock_harvestsource_patch",
+                             "mock_mark_deletion_patch",
+                             "mock_save_gather_error_patch")
+    @patch.object(S3RDFHarvester, '_get_s3_client_info')
+    def test_gather_stage_no_objects_found(
+            self, mock_get_s3_client_info,
+            s3_rdf_harvester, mock_harvest_job
+    ):
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {}  # No 'Contents'
+        mock_get_s3_client_info.return_value = ("my-bucket", mock_s3)
+
+        object_ids = s3_rdf_harvester.gather_stage(mock_harvest_job)
+
+        assert object_ids == [], "Should return an empty list if the bucket has no RDF objects."
+        mock_s3.list_objects_v2.assert_called_once_with(Bucket="my-bucket")
+
+
+    @pytest.mark.usefixtures("mock_harvestobject_patch",
+                             "mock_harvestsource_patch",
+                             "mock_mark_deletion_patch",
+                             "mock_save_gather_error_patch")
+    @patch.object(S3RDFHarvester, "_save_gather_error")
+    @patch.object(S3RDFHarvester, '_get_s3_client_info')
+    @patch('ckanext.gdi_userportal.harvesters.s3_rdf_harvester.RDFParser')
+    @patch('ckanext.harvest.model.Package.get')
+    def test_gather_stage_success_single_rdf(
+            self,
+            mock_package_get,
+            mock_rdf_parser_cls,
+            mock_get_s3_client_info,
+            mock_save_gather_error,
+            s3_rdf_harvester,
+            mock_harvest_job
+    ):
+        mock_s3 = MagicMock()
+
+        mock_s3.list_objects_v2.return_value = {
+            "Contents": [
+                {"Key": "dataset.rdf"}
+            ]
+        }
+
+        mock_s3.get_object.return_value = {
+            'Body': MagicMock(read=lambda: b"<rdf>Some RDF content</rdf>")
+        }
+        mock_get_s3_client_info.return_value = ("my-bucket", mock_s3)
+
+        mock_rdf_parser = MagicMock()
+
+        mock_rdf_parser.datasets.return_value = [{
+            "title": "Test Dataset",
+            "identifier": "test-guid-1234",
+            "extras": []
+        }]
+        mock_rdf_parser_cls.return_value = mock_rdf_parser
+
+
+        mock_source_package = MagicMock()
+        mock_source_package.owner_org = "org-id"
+        mock_source_package.url = "http://dataset/testurl"
+        mock_package_get.return_value = mock_source_package
+
+        object_ids = s3_rdf_harvester.gather_stage(mock_harvest_job)
+
+        assert not mock_save_gather_error.called, \
+            f"An error was logged instead of creating a HarvestObject: {mock_save_gather_error.call_args_list}"
+
+        assert len(object_ids) == 1, "Should produce exactly one HarvestObject ID."
+
+    @pytest.mark.usefixtures("mock_harvestobject_patch",
+                             "mock_harvestsource_patch",
+                             "mock_mark_deletion_patch",
+                             "mock_save_gather_error_patch")
+    @patch.object(S3RDFHarvester, '_get_s3_client_info')
+    @patch('ckanext.dcat.processors.RDFParser')
+    def test_gather_stage_rdf_parser_exception(
+            self,
+            mock_rdf_parser_cls,
+            mock_get_s3_client_info,
+            s3_rdf_harvester,
+            mock_harvest_job
+    ):
+
+        mock_s3 = MagicMock()
+
+        mock_s3.list_objects_v2.return_value = {
+            "Contents": [
+                {"Key": "bad_dataset.rdf"}
+            ]
+        }
+        mock_s3.get_object.return_value = {
+            'Body': MagicMock(read=lambda: b"bad RDF content")
+        }
+        mock_get_s3_client_info.return_value = ("my-bucket", mock_s3)
+
+        mock_rdf_parser = MagicMock()
+        mock_rdf_parser.parse.side_effect = RDFParserException("Parse error")
+        mock_rdf_parser_cls.return_value = mock_rdf_parser
+
+        object_ids = s3_rdf_harvester.gather_stage(mock_harvest_job)
+
+        assert object_ids == [], "Should return empty list when parse fails."
+
+
+    @pytest.mark.usefixtures("mock_harvestobject_patch",
+                             "mock_harvestsource_patch",
+                             "mock_mark_deletion_patch",
+                             "mock_save_gather_error_patch")
+    @patch.object(S3RDFHarvester, '_get_s3_client_info')
+    def test_gather_stage_aws_client_error(
+            self, mock_get_s3_client_info,
+            s3_rdf_harvester, mock_harvest_job
+    ):
+        mock_s3 = MagicMock()
+        error_response = {
+            'Error': {
+                'Code': 'AccessDenied',
+                'Message': 'Access Denied'
+            }
+        }
+        mock_s3.list_objects_v2.side_effect = ClientError(error_response, "ListObjects")
+        mock_get_s3_client_info.return_value = ("my-bucket", mock_s3)
+
+        object_ids = s3_rdf_harvester.gather_stage(mock_harvest_job)
+        assert object_ids == []
+
+
+    @pytest.mark.usefixtures("mock_harvestobject_patch",
+                             "mock_harvestsource_patch",
+                             "mock_mark_deletion_patch",
+                             "mock_save_gather_error_patch")
+    @patch.object(S3RDFHarvester, '_get_s3_client_info')
+    def test_gather_stage_boto_core_error(
+            self, mock_get_s3_client_info,
+            s3_rdf_harvester, mock_harvest_job
+    ):
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.side_effect = BotoCoreError(error_msg="Some BotoCore error")
+        mock_get_s3_client_info.return_value = ("my-bucket", mock_s3)
+
+        object_ids = s3_rdf_harvester.gather_stage(mock_harvest_job)
+        assert object_ids == []
+
+
+    @pytest.mark.usefixtures("mock_harvestobject_patch",
+                             "mock_harvestsource_patch",
+                             "mock_mark_deletion_patch",
+                             "mock_save_gather_error_patch")
+    @patch.object(S3RDFHarvester, '_get_s3_client_info')
+    def test_gather_stage_unexpected_error(
+            self, mock_get_s3_client_info,
+            s3_rdf_harvester, mock_harvest_job
+    ):
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.side_effect = RuntimeError("Unknown error")
+        mock_get_s3_client_info.return_value = ("my-bucket", mock_s3)
+
+        object_ids = s3_rdf_harvester.gather_stage(mock_harvest_job)
+        assert object_ids == []
+
+
+    @pytest.mark.usefixtures("mock_harvestobject_patch",
+                             "mock_harvestsource_patch",
+                             "mock_mark_deletion_patch",
+                             "mock_save_gather_error_patch")
+    @patch('ckanext.harvest.model.Package.get')
+    @patch.object(S3RDFHarvester, "_save_gather_error")
+    @patch.object(S3RDFHarvester, '_get_s3_client_info')
+    @patch('ckanext.gdi_userportal.harvesters.s3_rdf_harvester.RDFParser')
+    def test_gather_stage_with_custom_rdf_format(
+            self,
+            mock_rdf_parser_cls,
+            mock_get_s3_client_info,
+            mock_save_gather_error,
+            mock_package_get,
+            s3_rdf_harvester,
+            mock_harvest_job
+    ):
+        mock_harvest_job.source.config = json.dumps({"rdf_format": "turtle"})
+
+        mock_source_package = MagicMock()
+        mock_source_package.owner_org = "org-id"
+        mock_package_get.return_value = mock_source_package
+
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {
+            "Contents": [
+                {"Key": "dataset.ttl"}
+            ]
+        }
+        mock_s3.get_object.return_value = {
+            'Body': MagicMock(read=lambda: b"@prefix dcat: <http://www.w3.org/ns/dcat#> .")
+        }
+        mock_get_s3_client_info.return_value = ("my-bucket", mock_s3)
+
+        mock_rdf_parser = MagicMock()
+        mock_rdf_parser.datasets.return_value = [{
+            "title": "Test Dataset TTL",
+            "identifier": "test-guid-ttl",
+            "extras": []
+        }]
+        mock_rdf_parser_cls.return_value = mock_rdf_parser
+
+        object_ids = s3_rdf_harvester.gather_stage(mock_harvest_job)
+
+        assert not mock_save_gather_error.called, \
+            f"An error was logged instead of creating a HarvestObject: {mock_save_gather_error.call_args_list}"
+
+        assert len(object_ids) == 1, "Should create a HarvestObject when custom format is used."
+        mock_rdf_parser.parse.assert_called_once_with(
+            "@prefix dcat: <http://www.w3.org/ns/dcat#> .",
+            _format="turtle"
+        )
+
+
+class TestS3RDFHarvesterGetS3ClientInfo:
+
+    @patch('ckanext.harvest.model.HarvestSource.get')
+    def test_get_s3_client_info(
+            self, mock_harvestsource_get, s3_rdf_harvester, mock_harvest_job
+    ):
+        mock_source = MagicMock()
+        mock_source.url = "https://my-s3-endpoint.com/my-bucket"
+        mock_harvestsource_get.return_value = mock_source
+
+        with patch.object(config, 'get', side_effect=lambda key: {
+            'ckan.harvest.s3_rdf.aws_access_key': 'fake_access_key',
+            'ckan.harvest.s3_rdf.aws_secret_key': 'fake_secret_key'
+        }.get(key)):
+
+            bucket_name, s3_client = s3_rdf_harvester._get_s3_client_info(mock_harvest_job)
+
+        assert bucket_name == "my-bucket"
+        assert s3_client is not None
+        assert hasattr(s3_client, 'list_objects_v2')

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ opentelemetry-instrumentation-flask==0.49b2
 opentelemetry-exporter-otlp-proto-http==1.28.2
 ckantoolkit==0.0.7
 boto3==1.36.1
+botocore~=1.36.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ opentelemetry-instrumentation==0.49b2
 opentelemetry-instrumentation-flask==0.49b2
 opentelemetry-exporter-otlp-proto-http==1.28.2
 ckantoolkit==0.0.7
+boto3==1.36.1

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
     # pip to create the appropriate form of executable for the target platform.
     entry_points='''
         [ckan.plugins]
+        gdi_userportalharvester=ckanext.gdi_userportal.harvesters:S3RDFHarvester
         gdi_userportal=ckanext.gdi_userportal.plugin:GdiUserPortalPlugin
 
         [babel.extractors]

--- a/test.ini
+++ b/test.ini
@@ -12,8 +12,7 @@ use = config:../../src/ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here. These will override the one defined in CKAN core's test-core.ini
-ckan.plugins = gdi_userportal
-
+ckan.plugins = harvest dcat_rdf_harvester gdi_userportalharvester gdi_userportal
 
 # Logging configuration
 [loggers]

--- a/test.ini
+++ b/test.ini
@@ -9,6 +9,8 @@ error_email_from = ckan@localhost
 
 [app:main]
 use = config:../../src/ckan/test-core.ini
+ckanext.dcat.rdf.profiles = euro_dcat_ap
+sqlalchemy.url = postgresql://ckan_default:password@localhost:5432/ckan_default
 
 # Insert any custom config settings to be used when running your extension's
 # tests here. These will override the one defined in CKAN core's test-core.ini


### PR DESCRIPTION
## Summary by Sourcery

Add a new S3 RDF harvester to ingest RDF files from an S3 bucket.

New Features:
- Implement an S3 RDF harvester that retrieves RDF data from an S3 bucket and imports it into CKAN.

Tests:
- Update test configuration to include the new harvester plugin.