### PR TITLE
fix(ART-12367): fix dcat version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
           pip install --upgrade pytest-rerunfailures
           pip install -e 'git+https://github.com/CivityNL/ckanext-scheming.git@3.0.0-civity-1#egg=ckanext-scheming[requirements]'
           pip install -e 'git+https://github.com/ckan/ckanext-harvest.git@v1.6.0#egg=ckanext-harvest[requirements]'
-          pip install -e 'git+https://github.com/ckan/ckanext-dcat.git@v2.1.0#egg=ckanext-dcat[requirements]'
+          pip install -e 'git+https://github.com/ckan/ckanext-dcat.git@v2.2.0#egg=ckanext-dcat[requirements]'
           pip install -r https://raw.githubusercontent.com/ckan/ckanext-dcat/v2.1.0/requirements.txt
           pip install -r https://raw.githubusercontent.com/ckan/ckanext-harvest/v1.6.0/requirements.txt
           python3 setup.py develop


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Upgrade ckanext-dcat to v2.2.0 in CI workflow.