### PR TITLE
fix(release) Remove obsolete depency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
 
   publish-release:
     runs-on: ubuntu-latest
-    needs: [versioning, generate-changelog]
+    needs: versioning
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Simplified the release workflow by removing the 'generate-changelog' job dependency from the publish-release job