### PR TITLE
fix(accesservic) remove override of accesservice

### DIFF
--- a/ckanext/gdi_userportal/scheming/schemas/gdi_userportal.yaml
+++ b/ckanext/gdi_userportal/scheming/schemas/gdi_userportal.yaml
@@ -79,13 +79,3 @@ resource_fields:
     - field_name: end
       label: End
       preset: datetime_flex
-
-- field_name: access_services
-  label: Access services
-  repeating_label: Access service
-  repeating_subfields:
-    - field_name: modified
-      label: Modification date
-      preset: datetime_flex
-      help_text: Most recent date on which the dataset was changed, updated or modified.
-


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove the custom definition and subfields of access_services from the scheming schema