### PR TITLE
fix temporal and retention

### DIFF
--- a/ckanext/gdi_userportal/scheming/schemas/gdi_userportal.yaml
+++ b/ckanext/gdi_userportal/scheming/schemas/gdi_userportal.yaml
@@ -30,30 +30,6 @@ dataset_fields:
   help_text: "[dct:temporal] This property refers to a temporal period that the Dataset covers."
   preset: datetime_flex
 
-- field_name: retention_period
-  label: Retention period
-  repeating_subfields:
-    - field_name: start
-      label: Start
-      preset: datetime_flex
-
-    - field_name: end
-      label: End
-      preset: datetime_flex
-  help_text:  "A temporal period which the dataset is available for secondary use."
-
-- field_name: temporal_coverage
-  label: Temporal coverage
-  repeating_subfields:
-    - field_name: start
-      label: Start
-      preset: datetime_flex
-
-    - field_name: end
-      label: End
-      preset: datetime_flex
-  help_text: "The temporal period or periods the dataset covers."
-
 # Series fields
 - field_name: in_series
   preset: dataset_series_in_series


### PR DESCRIPTION
Fix retention period and temporal coverage by temporarily disabling it

## Summary by Sourcery

Remove retention_period and temporal_coverage fields from the GDI userportal scheming schema to temporarily disable them.

Bug Fixes:
- Temporarily disable retention_period field by removing its schema definition.
- Temporarily disable temporal_coverage field by removing its schema definition.