### PR TITLE
feat: Use of accept lang instead of CKAN LANG

### DIFF
--- a/ckanext/gdi_userportal/logic/action/get.py
+++ b/ckanext/gdi_userportal/logic/action/get.py
@@ -25,7 +25,8 @@ log = logging.getLogger(__name__)
 def enhanced_package_search(context, data_dict) -> Dict:
     result = toolkit.get_action("package_search")(context, data_dict)
     values_to_translate = collect_values_to_translate(result)
-    translations = get_translations(values_to_translate)
+    lang = toolkit.request.headers.get("Accept-Language")
+    translations = get_translations(values_to_translate, lang=lang)
     result["results"] = [
         replace_package(package, translations) for package in result["results"]
     ]
@@ -40,5 +41,6 @@ def enhanced_package_search(context, data_dict) -> Dict:
 def enhanced_package_show(context, data_dict) -> Dict:
     result = toolkit.get_action("package_show")(context, data_dict)
     values_to_translate = collect_values_to_translate(result)
+    lang = toolkit.request.headers.get("Accept-Language")
     translations = get_translations(values_to_translate)
     return replace_package(result, translations)

--- a/ckanext/gdi_userportal/logic/action/translation_utils.py
+++ b/ckanext/gdi_userportal/logic/action/translation_utils.py
@@ -32,16 +32,15 @@ class ValueLabel:
     count: int = None
 
 
-def get_translations(values_to_translate: List) -> Dict[str, str]:
+def get_translations(values_to_translate: List, lang: str = DEFAULT_FALLBACK_LANG) -> Dict[str, str]:
     """Calls term_translation_show action with a list of values to translate"""
-    pref_language = _get_language()
-    fallback_language = config.get("ckan.locale_default", DEFAULT_FALLBACK_LANG)
+    pref_language = _get_language(lang)
 
     translation_table = toolkit.get_action("term_translation_show")(
         {},
         {
             "terms": values_to_translate,
-            "lang_codes": (pref_language, fallback_language),
+            "lang_codes": (pref_language, DEFAULT_FALLBACK_LANG),
         },
     )
 
@@ -49,7 +48,7 @@ def get_translations(values_to_translate: List) -> Dict[str, str]:
     translations = {
         transl_item["term"]: transl_item["term_translation"]
         for transl_item in translation_table
-        if (transl_item["lang_code"] == fallback_language)
+        if (transl_item["lang_code"] == DEFAULT_FALLBACK_LANG)
     }
 
     # Override with preferred language
@@ -60,13 +59,13 @@ def get_translations(values_to_translate: List) -> Dict[str, str]:
     return translations
 
 
-def _get_language() -> str:
+def _get_language(lang: str) -> str:
     """
     Tries to get default language from environment variables/ckan config, defaults to English
     """
     language = DEFAULT_FALLBACK_LANG
     try:
-        language = request.environ["CKAN_LANG"]
+        language = lang
     except (TypeError, KeyError):
         try:
             language = config["ckan.locale_default"]


### PR DESCRIPTION
## Summary by Sourcery

Use the HTTP Accept-Language header to drive platform translations instead of relying on CKAN_LANG, and simplify fallback logic

New Features:
- Support passing the Accept-Language header to the translation utility in enhanced package search

Enhancements:
- Refactor get_translations to accept an explicit language parameter and drop secondary config-based fallback
- Simplify translation lookup to always fall back to the default language constant
- Refactor _get_language to use the provided language argument instead of reading CKAN_ENV