### PR TITLE
normalise accept language

### DIFF
--- a/ckanext/gdi_userportal/logic/action/get.py
+++ b/ckanext/gdi_userportal/logic/action/get.py
@@ -42,5 +42,5 @@ def enhanced_package_show(context, data_dict) -> Dict:
     result = toolkit.get_action("package_show")(context, data_dict)
     values_to_translate = collect_values_to_translate(result)
     lang = toolkit.request.headers.get("Accept-Language")
-    translations = get_translations(values_to_translate)
+    translations = get_translations(values_to_translate, lang=lang)
     return replace_package(result, translations)

--- a/ckanext/gdi_userportal/logic/action/translation_utils.py
+++ b/ckanext/gdi_userportal/logic/action/translation_utils.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass
+import logging
 from typing import Any, Dict, List
 
 from ckan.common import config, request
@@ -25,6 +26,7 @@ RESOURCE_REPLACE_FIELDS = ["format", "language"]
 DEFAULT_FALLBACK_LANG = "en"
 SUPPORTED_LANGUAGES = {DEFAULT_FALLBACK_LANG, "nl"}
 
+log = logging.getLogger(__name__)
 
 @dataclass
 class ValueLabel:
@@ -80,6 +82,9 @@ def _get_language(lang: str) -> str:
     language = _normalize_language(lang)
 
     if not language:
+        log.warning(
+            "Could not determine preferred language from request headers, falling back to CKAN config"
+        )
         language = _normalize_language(config.get("ckan.locale_default"))
 
     if language not in SUPPORTED_LANGUAGES:


### PR DESCRIPTION
## Summary by Sourcery

Normalize and validate the requested language from the Accept-Language header before fetching translations, and ensure only supported languages (en, nl) are used with a fallback to English.

Enhancements:
- Add _normalize_language utility to sanitize and extract primary language codes
- Introduce SUPPORTED_LANGUAGES set and enforce fallback to DEFAULT_FALLBACK_LANG for unsupported or invalid codes
- Refactor _get_language to use normalization and fall back on CKAN config or default as needed
- Pass Accept-Language header value into get_translations for language-aware translation