### PR TITLE
Replace pytz with zoneinfo for timezone handling

### DIFF
--- a/ckanext/gdi_userportal/tests/test_scheming.py
+++ b/ckanext/gdi_userportal/tests/test_scheming.py
@@ -6,16 +6,16 @@
 This module tests the scheming related parts of the GDI userportal plugin (validation.py)
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import ckanext.gdi_userportal.validation as validation
 import pytest
-import pytz
+from zoneinfo import ZoneInfo
 
 
 @pytest.fixture
 def time_nye():
-    return datetime(2020, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
+    return datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 
 
 @pytest.mark.parametrize(
@@ -23,15 +23,15 @@ def time_nye():
     [
         # No timezone defined
         datetime(2020, 1, 1),
-        # Time ahead
-        pytz.timezone("CET").localize(datetime(2020, 1, 1, 1, 0)),
+        # Time ahead (CET is equivalent to Europe/Paris/Amsterdam; use a canonical tz)
+        datetime(2020, 1, 1, 1, 0).replace(tzinfo=ZoneInfo("CET")),
         # Time behind
-        pytz.timezone("America/Chicago").localize(datetime(2019, 12, 31, 18, 0, 0)),
-        # Timezone with more than just hours and microseconds
-        pytz.timezone("Asia/Kolkata").localize(datetime(2020, 1, 1, 5, 30, 0, 987654)),
+        datetime(2019, 12, 31, 18, 0, 0).replace(tzinfo=ZoneInfo("America/Chicago")),
+        # Timezone with half hour offset and microseconds
+        datetime(2020, 1, 1, 5, 30, 0, 987654).replace(tzinfo=ZoneInfo("Asia/Kolkata")),
     ],
 )
 def test_utc_enforcer(time, time_nye):
     result = validation.enforce_utc_time(time)
     assert result == time_nye
-    assert result.tzinfo == pytz.UTC
+    assert result.tzinfo == timezone.utc

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 python-dateutil==2.9.0.post0
-pytz==2025.2
 opentelemetry-api==1.36.0
 opentelemetry-sdk==1.36.0
 opentelemetry-instrumentation==0.57b0


### PR DESCRIPTION
Refactored code and tests to use Python's standard library zoneinfo module instead of pytz for timezone management. Updated datetime handling to use timezone.utc and ZoneInfo, and removed pytz from requirements.txt.