### PR TITLE
fix(versioning) fix versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,9 @@ jobs:
           echo "Updating : $INCREMENT version"
           
           case "$INCREMENT" in
-            major) ((MAJOR++)); MINOR=0; PATCH=0 ;;
-            minor) ((MINOR++)); PATCH=0 ;;
-            patch|*) ((PATCH++)) ;;
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch|*) PATCH=$((PATCH + 1)) ;;
           esac
 
           NEW_TAG="v$MAJOR.$MINOR.$PATCH"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Replace Bash-only ((...)) increments with MAJOR=$((MAJOR+1)), MINOR=$((MINOR+1)), and PATCH=$((PATCH+1)) calls to fix versioning in shell