### PR TITLE
Add OTLP gRPC exporter dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ opentelemetry-api==1.40.0
 opentelemetry-sdk==1.40.0
 opentelemetry-instrumentation==0.61b0
 opentelemetry-instrumentation-flask==0.61b0
+opentelemetry-exporter-otlp-proto-grpc==1.40.0
 opentelemetry-exporter-otlp-proto-http==1.40.0
 ckantoolkit==0.0.7
 boto3==1.42.74


### PR DESCRIPTION
## Summary
- add the OTLP gRPC exporter to the extension requirements
- align it with the existing OpenTelemetry 1.40.0 dependency set

## Why
The Docker image no longer needs to pin the gRPC exporter separately once this tag is consumed downstream.