### PR TITLE
Turn off indexing for some schema fields; add distribution

### DIFF
--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -164,12 +164,13 @@ attribute with the form `ckan-X.Y` -->
         <field name="access_rights" type="string" indexed="true" stored="true" multiValued="false" />
         <field name="conforms_to" type="string" indexed="true" stored="true" multiValued="true" />
         <field name="has_version" type="string" indexed="true" stored="true" multiValued="true" />
-        <field name="identifier" type="string" indexed="true" stored="true" multiValued="false" />
+        <field name="identifier" type="string" indexed="false" stored="true" multiValued="false" />
         <field name="language" type="string" indexed="true" stored="true" multiValued="true" />
         <field name="uri" type="string" indexed="true" stored="true" multiValued="false" />
         <field name="provenance" type="string" indexed="true" stored="true" multiValued="false" />
         <field name="spatial_uri" type="string" indexed="true" stored="true" multiValued="false" />
-        <field name="documentation" type="string" indexed="true" stored="true" multiValued="true" />
+        <field name="documentation" type="string" indexed="false" stored="true" multiValued="true" />
+        <field name="distribution" type="string" indexed="false" stored="true" multiValued="true" />
         <field name="purpose" type="string" indexed="true" stored="true" multiValued="true" />
         <field name="resources_formats" type="string" indexed="true" stored="true"
             multiValued="true" />


### PR DESCRIPTION
Update solr/schema.xml: set identifier and documentation fields to indexed="false" (previously true) so they are stored but not searchable, and add a new multivalued distribution field (stored, not indexed). This reduces indexed data for these metadata fields while keeping their values retrievable from stored fields.

## Summary by Sourcery

Adjust Solr schema metadata indexing and add a new stored distribution field.

New Features:
- Add a new multivalued, stored-only distribution field to the Solr schema.

Enhancements:
- Stop indexing the identifier and documentation metadata fields while keeping them stored for retrieval.