### PR TITLE
Use multiple_text for URL fields; add Solr field

### DIFF
--- a/ckanext/gdi_userportal/scheming/schemas/dataset_multilingual.yaml
+++ b/ckanext/gdi_userportal/scheming/schemas/dataset_multilingual.yaml
@@ -57,7 +57,8 @@ dataset_fields:
 
       - field_name: url
         label: URL
-        display_snippet: link.html
+        preset: multiple_text
+        validators: ignore_missing scheming_multiple_text
         help_text: URL for more information about the contact point.
     help_text: Contact information for enquiries about the dataset.
 
@@ -879,6 +880,8 @@ resource_fields:
 
           - field_name: url
             label: URL
+            preset: multiple_text
+            validators: ignore_missing scheming_multiple_text
             display_snippet: link.html
         help_text: Contact information for enquiries about the data service.
 

--- a/ckanext/gdi_userportal/scheming/schemas/dataset_series_multilingual.yaml
+++ b/ckanext/gdi_userportal/scheming/schemas/dataset_series_multilingual.yaml
@@ -53,7 +53,8 @@ dataset_fields:
 
       - field_name: url
         label: URL
-        display_snippet: link.html
+        preset: multiple_text
+        validators: ignore_missing scheming_multiple_text
 
     help_text: Contact information for enquiries about the dataset series.
 

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -174,6 +174,7 @@ attribute with the form `ckan-X.Y` -->
         <field name="purpose" type="string" indexed="true" stored="true" multiValued="true" />
         <field name="resources_formats" type="string" indexed="true" stored="true"
             multiValued="true" />
+        <field name="applicable_legislation" type="string" indexed="false" stored="true" multiValued="true"/>
 
         <field name="contact_point_uri" type="string" indexed="true" stored="true"
             multiValued="true" />


### PR DESCRIPTION
Update scheming schemas to treat URL fields as multiple_text entries by adding preset: multiple_text and validators: ignore_missing scheming_multiple_text for dataset and resource URL fields (dataset_multilingual and dataset_series_multilingual). Add a new Solr field applicable_legislation (string, stored, multiValued, not indexed) so applicable legislation values are persisted and retrievable from Solr.

## Summary by Sourcery

Treat dataset and resource URL fields as multi-valued text and persist applicable legislation values in Solr.

New Features:
- Add a Solr field to store applicable legislation values without indexing them.

Enhancements:
- Update dataset and resource URL fields in multilingual scheming schemas to use multi-valued text configuration.