### PR TITLE
Add qualified attribution fields and indexing

### DIFF
--- a/ckanext/gdi_userportal/plugin.py
+++ b/ckanext/gdi_userportal/plugin.py
@@ -140,6 +140,12 @@ class GdiUserPortalPlugin(plugins.SingletonPlugin):
     def _update_facets(self, facets_dict):
         facets_dict.pop("groups", None)
         facets_dict["vocab_in_series_title"] = toolkit._("Dataset series")
+        facets_dict["vocab_qualified_attribution_role"] = toolkit._(
+            "Qualified attribution role"
+        )
+        facets_dict["vocab_qualified_attribution_agent_name"] = toolkit._(
+            "Qualified attribution organization"
+        )
         return facets_dict
 
     def dataset_facets(self, facets_dict, package_type):
@@ -474,6 +480,69 @@ class GdiUserPortalPlugin(plugins.SingletonPlugin):
 
         if data_dict.get("res_format"):
             data_dict["res_format"] = list(dict.fromkeys(data_dict.get("res_format")))
+
+        qualified_attribution_roles = []
+        qualified_attribution_agent_names = []
+        qualified_attribution = self._parse_json_if_possible(
+            data_dict.get("qualified_attribution")
+        )
+        if isinstance(qualified_attribution, dict):
+            qualified_attribution = [qualified_attribution]
+
+        if isinstance(qualified_attribution, list):
+            for attribution in qualified_attribution:
+                if not isinstance(attribution, dict):
+                    continue
+
+                qualified_attribution_roles.extend(
+                    self._extract_string_values(attribution.get("role"))
+                )
+
+                agents = attribution.get("agent")
+                if isinstance(agents, dict):
+                    agents = [agents]
+                if not isinstance(agents, list):
+                    continue
+
+                for agent in agents:
+                    if isinstance(agent, str):
+                        qualified_attribution_agent_names.append(agent)
+                        continue
+                    if not isinstance(agent, dict):
+                        continue
+
+                    agent_name = agent.get("name")
+                    if isinstance(agent_name, str):
+                        qualified_attribution_agent_names.append(agent_name)
+                    elif isinstance(agent_name, dict):
+                        qualified_attribution_agent_names.extend(
+                            [
+                                value
+                                for value in agent_name.values()
+                                if isinstance(value, str)
+                            ]
+                        )
+                    elif isinstance(agent_name, list):
+                        qualified_attribution_agent_names.extend(
+                            [value for value in agent_name if isinstance(value, str)]
+                        )
+
+        qualified_attribution_roles = _deduplicate_non_empty_strings(
+            qualified_attribution_roles
+        )
+        qualified_attribution_agent_names = _deduplicate_non_empty_strings(
+            qualified_attribution_agent_names
+        )
+
+        if qualified_attribution_roles:
+            data_dict["vocab_qualified_attribution_role"] = qualified_attribution_roles
+        if qualified_attribution_agent_names:
+            data_dict["vocab_qualified_attribution_agent_name"] = (
+                qualified_attribution_agent_names
+            )
+            data_dict["qualified_attribution_agent_name"] = (
+                qualified_attribution_agent_names
+            )
 
         data_dict = self._parse_agent_name(data_dict, "publisher")
         data_dict = self._parse_agent_name(data_dict, "creator")

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -199,6 +199,9 @@ attribute with the form `ckan-X.Y` -->
         <field name="publisher_identifier" type="string" indexed="true" stored="true"
             multiValued="true" />
 
+        <field name="qualified_attribution_agent_name" type="text_general" indexed="true" stored="true" multiValued="true" />
+        <field name="qualified_attribution_agent_name_ngram" type="text_ngram" indexed="true" stored="false" multiValued="true" />
+
         <field name="capacity" type="string" indexed="true" stored="true" multiValued="false" />
         <field name="permission_labels" type="string" indexed="true" stored="false"
             multiValued="true" />
@@ -279,4 +282,6 @@ attribute with the form `ckan-X.Y` -->
     <copyField source="creator_name" dest="text" />
     <copyField source="contact_name" dest="text" />
     <copyField source="publisher_name" dest="text" />
+    <copyField source="qualified_attribution_agent_name" dest="text" />
+    <copyField source="qualified_attribution_agent_name" dest="qualified_attribution_agent_name_ngram" />
 </schema>


### PR DESCRIPTION
Add support for qualified attribution in the user portal plugin and Solr schema. The plugin now exposes new dataset facets (vocab_qualified_attribution_role and vocab_qualified_attribution_agent_name), parses the qualified_attribution JSON payload (handling dicts, lists, strings and nested agent name formats), deduplicates and populates vocab fields as well as qualified_attribution_agent_name for indexing/search. The Solr schema was updated with qualified_attribution_agent_name and an ngram variant, and copyField entries were added so agent names are included in the main text field and available for partial-match searches.

## Summary by Sourcery

Add indexing and search support for qualified attribution metadata in the user portal and Solr schema.

New Features:
- Expose new dataset facets for qualified attribution role and organization in the user portal.
- Index qualified attribution roles and agent names from the JSON payload into dedicated vocab and search fields.
- Enable partial and full-text search over qualified attribution agent names via new Solr fields and copyField mappings.