### PR TITLE
Add multilingual filter help text for title

### DIFF
--- a/ckanext/gdi_userportal/logic/action/get.py
+++ b/ckanext/gdi_userportal/logic/action/get.py
@@ -86,7 +86,7 @@ def _parse_requested_keys(keys: Any) -> Optional[Set[str]]:
         raise toolkit.ValidationError({"keys": "Must be a list of strings"})
 
     parsed_keys = {key.strip() for key in keys if isinstance(key, str) and key.strip()}
-    return parsed_keys or None
+    return parsed_keys
 
 
 def _localized_text(value: Any, language: str) -> str:

--- a/ckanext/gdi_userportal/logic/action/get.py
+++ b/ckanext/gdi_userportal/logic/action/get.py
@@ -7,21 +7,24 @@
 
 # -*- coding: utf-8 -*-
 
+import json
 from ckan.plugins import toolkit
 from ckanext.gdi_userportal.logic.action.translation_utils import (
     collect_values_to_translate,
+    get_request_language,
     get_translations,
+    _get_language,
     replace_package,
     replace_search_facets,
 )
-from typing import Dict
+from typing import Any, Dict, Optional, Set
 
 
 @toolkit.side_effect_free
 def enhanced_package_search(context, data_dict) -> Dict:
     result = toolkit.get_action("package_search")(context, data_dict)
     values_to_translate = collect_values_to_translate(result)
-    lang = toolkit.request.headers.get("Accept-Language")
+    lang = get_request_language()
     translations = get_translations(values_to_translate, lang=lang)
     result["results"] = [
         replace_package(package, translations, lang=lang)
@@ -38,6 +41,59 @@ def enhanced_package_search(context, data_dict) -> Dict:
 def enhanced_package_show(context, data_dict) -> Dict:
     result = toolkit.get_action("package_show")(context, data_dict)
     values_to_translate = collect_values_to_translate(result)
-    lang = toolkit.request.headers.get("Accept-Language")
+    lang = get_request_language()
     translations = get_translations(values_to_translate, lang=lang)
     return replace_package(result, translations, lang=lang)
+
+
+@toolkit.side_effect_free
+def gdi_filter_help_texts_show(context, data_dict) -> Dict[str, str]:
+    data_dict = data_dict or {}
+    dataset_type = data_dict.get("type", "dataset")
+    requested_keys = _parse_requested_keys(data_dict.get("keys"))
+    language = _get_language(get_request_language())
+
+    schema = toolkit.get_action("scheming_dataset_schema_show")(
+        context, {"type": dataset_type}
+    )
+
+    help_texts = {}
+    for field in schema.get("dataset_fields", []):
+        filter_key = field.get("filter_key")
+        if not filter_key or (requested_keys is not None and filter_key not in requested_keys):
+            continue
+
+        help_text = _localized_text(
+            field.get("filter_help_text") or field.get("help_text"), language
+        )
+        if help_text:
+            help_texts[filter_key] = help_text
+
+    return help_texts
+
+
+def _parse_requested_keys(keys: Any) -> Optional[Set[str]]:
+    if keys is None or keys == "":
+        return None
+
+    if isinstance(keys, str):
+        try:
+            keys = json.loads(keys)
+        except ValueError:
+            keys = [key.strip() for key in keys.split(",")]
+
+    if not isinstance(keys, (list, tuple, set)):
+        raise toolkit.ValidationError({"keys": "Must be a list of strings"})
+
+    parsed_keys = {key.strip() for key in keys if isinstance(key, str) and key.strip()}
+    return parsed_keys or None
+
+
+def _localized_text(value: Any, language: str) -> str:
+    if isinstance(value, dict):
+        return value.get(language) or value.get("en") or ""
+
+    if isinstance(value, str):
+        return value
+
+    return ""

--- a/ckanext/gdi_userportal/logic/action/get.py
+++ b/ckanext/gdi_userportal/logic/action/get.py
@@ -47,7 +47,7 @@ def enhanced_package_show(context, data_dict) -> Dict:
 
 
 @toolkit.side_effect_free
-def gdi_filter_help_texts_show(context, data_dict) -> Dict[str, str]:
+def gdi_filter_help_texts_show(context, data_dict=None) -> Dict[str, str]:
     data_dict = data_dict or {}
     dataset_type = data_dict.get("type", "dataset")
     requested_keys = _parse_requested_keys(data_dict.get("keys"))

--- a/ckanext/gdi_userportal/logic/action/get.py
+++ b/ckanext/gdi_userportal/logic/action/get.py
@@ -83,7 +83,7 @@ def _parse_requested_keys(keys: Any) -> Optional[Set[str]]:
             keys = [key.strip() for key in keys.split(",")]
 
     if not isinstance(keys, (list, tuple, set)):
-        raise toolkit.ValidationError({"keys": "Must be a list of strings"})
+        raise toolkit.ValidationError({"keys": ["Must be a list of strings"]})
 
     parsed_keys = {key.strip() for key in keys if isinstance(key, str) and key.strip()}
     return parsed_keys

--- a/ckanext/gdi_userportal/logic/action/get.py
+++ b/ckanext/gdi_userportal/logic/action/get.py
@@ -12,8 +12,8 @@ from ckan.plugins import toolkit
 from ckanext.gdi_userportal.logic.action.translation_utils import (
     collect_values_to_translate,
     get_request_language,
+    get_preferred_language,
     get_translations,
-    _get_language,
     replace_package,
     replace_search_facets,
 )
@@ -51,7 +51,7 @@ def gdi_filter_help_texts_show(context, data_dict) -> Dict[str, str]:
     data_dict = data_dict or {}
     dataset_type = data_dict.get("type", "dataset")
     requested_keys = _parse_requested_keys(data_dict.get("keys"))
-    language = _get_language(get_request_language())
+    language = get_preferred_language(get_request_language())
 
     schema = toolkit.get_action("scheming_dataset_schema_show")(
         context, {"type": dataset_type}

--- a/ckanext/gdi_userportal/logic/action/get.py
+++ b/ckanext/gdi_userportal/logic/action/get.py
@@ -59,15 +59,15 @@ def gdi_filter_help_texts_show(context, data_dict) -> Dict[str, str]:
 
     help_texts = {}
     for field in schema.get("dataset_fields", []):
-        filter_key = field.get("filter_key")
-        if not filter_key or (requested_keys is not None and filter_key not in requested_keys):
+        facet_key = field.get("facet_key")
+        if not facet_key or (requested_keys is not None and facet_key not in requested_keys):
             continue
 
         help_text = _localized_text(
             field.get("filter_help_text") or field.get("help_text"), language
         )
         if help_text:
-            help_texts[filter_key] = help_text
+            help_texts[facet_key] = help_text
 
     return help_texts
 

--- a/ckanext/gdi_userportal/logic/action/post.py
+++ b/ckanext/gdi_userportal/logic/action/post.py
@@ -7,6 +7,7 @@ import logging
 from ckan.plugins import toolkit
 from ckanext.gdi_userportal.logic.action.translation_utils import (
     collect_values_to_translate,
+    get_request_language,
     get_translations,
     replace_package,
     replace_search_facets,
@@ -25,7 +26,7 @@ def enhanced_package_search(context, data_dict=None) -> Dict:
     try:
         result = toolkit.get_action("package_search")(context, data_dict)
         values_to_translate = collect_values_to_translate(result)
-        lang = toolkit.request.headers.get("Accept-Language")
+        lang = get_request_language()
         translations = get_translations(values_to_translate, lang=lang)
 
         result["results"] = [

--- a/ckanext/gdi_userportal/logic/action/translation_utils.py
+++ b/ckanext/gdi_userportal/logic/action/translation_utils.py
@@ -134,6 +134,13 @@ def get_translations(values_to_translate: List, lang: str = DEFAULT_FALLBACK_LAN
     return translations
 
 
+def get_request_language() -> Optional[str]:
+    try:
+        return toolkit.request.headers.get("Accept-Language")
+    except RuntimeError:
+        return None
+
+
 def _deduplicate_non_empty_strings(values: List[Any]) -> List[str]:
     seen = set()
     deduplicated = []

--- a/ckanext/gdi_userportal/logic/action/translation_utils.py
+++ b/ckanext/gdi_userportal/logic/action/translation_utils.py
@@ -107,7 +107,7 @@ class ValueLabel:
     count: int = None
 
 
-def get_translations(values_to_translate: List, lang: str = DEFAULT_FALLBACK_LANG) -> Dict[str, str]:
+def get_translations(values_to_translate: List, lang: Optional[str] = DEFAULT_FALLBACK_LANG) -> Dict[str, str]:
     """Calls term_translation_show action with a list of values to translate"""
     pref_language = get_preferred_language(lang)
 

--- a/ckanext/gdi_userportal/logic/action/translation_utils.py
+++ b/ckanext/gdi_userportal/logic/action/translation_utils.py
@@ -201,7 +201,7 @@ def _normalize_language(lang_value: Any) -> str:
     return primary.lower()
 
 
-def get_preferred_language(lang: str) -> str:
+def get_preferred_language(lang: Optional[str]) -> str:
     """
     Tries to get default language from environment variables/ckan config, defaults to English
     """

--- a/ckanext/gdi_userportal/logic/action/translation_utils.py
+++ b/ckanext/gdi_userportal/logic/action/translation_utils.py
@@ -109,7 +109,7 @@ class ValueLabel:
 
 def get_translations(values_to_translate: List, lang: str = DEFAULT_FALLBACK_LANG) -> Dict[str, str]:
     """Calls term_translation_show action with a list of values to translate"""
-    pref_language = _get_language(lang)
+    pref_language = get_preferred_language(lang)
 
     translation_table = toolkit.get_action("term_translation_show")(
         {},
@@ -201,7 +201,7 @@ def _normalize_language(lang_value: Any) -> str:
     return primary.lower()
 
 
-def _get_language(lang: str) -> str:
+def get_preferred_language(lang: str) -> str:
     """
     Tries to get default language from environment variables/ckan config, defaults to English
     """
@@ -217,6 +217,10 @@ def _get_language(lang: str) -> str:
         language = DEFAULT_FALLBACK_LANG
 
     return language
+
+
+def _get_language(lang: str) -> str:
+    return get_preferred_language(lang)
 
 
 def _select_and_append_values(
@@ -295,7 +299,7 @@ def collect_values_to_translate(data: Any) -> List:
 
 
 def replace_package(data, translation_dict, lang: Optional[str] = None):
-    preferred_lang = _get_language(lang)
+    preferred_lang = get_preferred_language(lang)
 
     _apply_translated_properties(data, preferred_lang)
     _merge_tags_translated_into_tags(data)
@@ -485,7 +489,7 @@ def _change_facet(facet, translation_dict):
 
 
 def replace_search_facets(data, translation_dict, lang):
-    preferred_lang = _get_language(lang)
+    preferred_lang = get_preferred_language(lang)
     new_facets = {}
     for key, facet in data.items():
         title = facet["title"]

--- a/ckanext/gdi_userportal/logic/auth/get.py
+++ b/ckanext/gdi_userportal/logic/auth/get.py
@@ -20,3 +20,8 @@ def config_option_show(next_auth, context, data_dict=None):
         return {'success': True}
 
     return next_auth(context, data_dict)
+
+
+@toolkit.auth_allow_anonymous_access
+def gdi_filter_help_texts_show(context, data_dict=None):
+    return {"success": True}

--- a/ckanext/gdi_userportal/plugin.py
+++ b/ckanext/gdi_userportal/plugin.py
@@ -16,6 +16,7 @@ from ckanext.gdi_userportal.logic.action.translation_utils import (
 from ckanext.gdi_userportal.logic.action.get import (
     enhanced_package_search,
     enhanced_package_show,
+    gdi_filter_help_texts_show,
 )
 from ckanext.gdi_userportal.logic.auth.get import config_option_show
 from ckanext.gdi_userportal.validation import scheming_isodatetime_flex
@@ -160,6 +161,7 @@ class GdiUserPortalPlugin(plugins.SingletonPlugin):
         return {
             "enhanced_package_search": enhanced_package_search,
             "enhanced_package_show": enhanced_package_show,
+            "gdi_filter_help_texts_show": gdi_filter_help_texts_show,
         }
 
     def get_helpers(self):

--- a/ckanext/gdi_userportal/plugin.py
+++ b/ckanext/gdi_userportal/plugin.py
@@ -18,7 +18,10 @@ from ckanext.gdi_userportal.logic.action.get import (
     enhanced_package_show,
     gdi_filter_help_texts_show,
 )
-from ckanext.gdi_userportal.logic.auth.get import config_option_show
+from ckanext.gdi_userportal.logic.auth.get import (
+    config_option_show,
+    gdi_filter_help_texts_show as gdi_filter_help_texts_show_auth,
+)
 from ckanext.gdi_userportal.validation import scheming_isodatetime_flex
 
 from opentelemetry import metrics
@@ -152,10 +155,13 @@ class GdiUserPortalPlugin(plugins.SingletonPlugin):
     def organization_facets(self, facets_dict, organization_type, package_type):
         return self._update_facets(facets_dict)
 
-        # IAuthFunctions
+    # IAuthFunctions
 
     def get_auth_functions(self):
-        return {"config_option_show": config_option_show}
+        return {
+            "config_option_show": config_option_show,
+            "gdi_filter_help_texts_show": gdi_filter_help_texts_show_auth,
+        }
 
     def get_actions(self):
         return {

--- a/ckanext/gdi_userportal/scheming/schemas/dataset_multilingual.yaml
+++ b/ckanext/gdi_userportal/scheming/schemas/dataset_multilingual.yaml
@@ -13,7 +13,13 @@ dataset_fields:
   - field_name: title_translated
     label: Title
     preset: fluent_core_translated
-    help_text: A descriptive title for the dataset.
+    help_text:
+      en: A descriptive title for the dataset.
+      nl: Een beschrijvende titel voor de dataset.
+    filter_help_text:
+      en: Use this filter to search datasets by title.
+      nl: Gebruik deze filter om datasets op titel te zoeken.
+    filter_key: title
 
   - field_name: name
     label: URL

--- a/ckanext/gdi_userportal/scheming/schemas/dataset_multilingual.yaml
+++ b/ckanext/gdi_userportal/scheming/schemas/dataset_multilingual.yaml
@@ -38,6 +38,10 @@ dataset_fields:
     preset: fluent_tags
     form_placeholder: eg. economy, mental health, government
     help_text: Keywords or tags describing the dataset. Use commas to separate multiple values.
+    filter_help_text:
+      en: Use this filter to search datasets by keywords.
+      nl: Gebruik deze filter om datasets op trefwoorden te zoeken.
+    facet_key: tags
 
   - field_name: contact
     label: Contact points
@@ -177,12 +181,20 @@ dataset_fields:
     label: Release date
     preset: datetime_flex
     help_text: Date of publication of the dataset.
+    filter_help_text:
+      en: Use this filter to search datasets by release date.
+      nl: Gebruik deze filter om datasets op releasedatum te zoeken.
+    facet_key: issued
 
   # Note: this will fall back to metadata_modified if not present
   - field_name: modified
     label: Modification date
     preset: datetime_flex
     help_text: Most recent date on which the dataset was changed, updated or modified.
+    filter_help_text:
+      en: Use this filter to search datasets by modification date.
+      nl: Gebruik deze filter om datasets op wijzigingsdatum te zoeken.
+    facet_key: modified
 
   - field_name: in_series
     preset: dataset_series_in_series
@@ -205,6 +217,10 @@ dataset_fields:
   - field_name: frequency
     label: Frequency
     help_text: The frequency at which dataset is published.
+    filter_help_text:
+      en: Use this filter to search datasets by publication frequency.
+      nl: Gebruik deze filter om datasets op publicatiefrequentie te zoeken.
+    facet_key: frequency
 
   - field_name: provenance
     label: Provenance
@@ -259,24 +275,40 @@ dataset_fields:
     label: Access rights
     validators: ignore_missing unicode_safe
     help_text: Information that indicates whether the dataset is Open Data, has access restrictions or is not public.
+    filter_help_text:
+      en: Use this filter to search datasets by access rights.
+      nl: Gebruik deze filter om datasets op toegangsrechten te zoeken.
+    facet_key: access_rights
 
   - field_name: alternate_identifier
     label: Other identifier
     preset: multiple_text
     validators: ignore_missing scheming_multiple_text
     help_text: This property refers to a secondary identifier of the dataset, such as MAST/ADS, DataCite, DOI, etc.
+    filter_help_text:
+      en: Use this filter to search datasets by other identifiers.
+      nl: Gebruik deze filter om datasets op andere identificatoren te zoeken.
+    facet_key: alternate_identifier
 
   - field_name: theme
     label: Theme
     preset: multiple_text
     validators: ignore_missing scheming_multiple_text
     help_text: A category of the dataset. A Dataset may be associated with multiple themes.
+    filter_help_text:
+      en: Use this filter to search datasets by theme.
+      nl: Gebruik deze filter om datasets op thema te zoeken.
+    facet_key: theme
 
   - field_name: language
     label: Language
     preset: multiple_text
     validators: ignore_missing scheming_multiple_text
     help_text: Language or languages of the dataset.
+    filter_help_text:
+      en: Use this filter to search datasets by language.
+      nl: Gebruik deze filter om datasets op taal te zoeken.
+    facet_key: language
     # TODO: language form snippet / validator / graph
 
   - field_name: documentation
@@ -290,12 +322,20 @@ dataset_fields:
     preset: multiple_text
     validators: ignore_missing scheming_multiple_text
     help_text: An implementing rule or other specification that the dataset follows.
+    filter_help_text:
+      en: Use this filter to search datasets by conformance specification.
+      nl: Gebruik deze filter om datasets op specificatie te zoeken.
+    facet_key: conforms_to
 
   - field_name: is_referenced_by
     label: Is referenced by
     preset: multiple_text
     validators: ignore_missing scheming_multiple_text
     help_text: A related resource, such as a publication, that references, cites, or otherwise points to the dataset.
+    filter_help_text:
+      en: Use this filter to search datasets by related references.
+      nl: Gebruik deze filter om datasets op verwijzingen te zoeken.
+    facet_key: is_referenced_by
 
   - field_name: distribution
     label: Distribution
@@ -338,6 +378,10 @@ dataset_fields:
     preset: multiple_text
     validators: ignore_missing scheming_multiple_text
     help_text: Health classifications and their codes associated with the dataset.
+    filter_help_text:
+      en: Use this filter to search datasets by code values.
+      nl: Gebruik deze filter om datasets op codewaarden te zoeken.
+    facet_key: code_values
 
   - field_name: coding_system
     label: Coding system
@@ -346,6 +390,10 @@ dataset_fields:
     help_text: >
       Coding systems in use (e.g., ICD-10-CM, DGRs, SNOMED CT, ...).
       To comply with HealthDCAT-AP, Wikidata URIs MUST be used.
+    filter_help_text:
+      en: Use this filter to search datasets by coding system.
+      nl: Gebruik deze filter om datasets op coderingssysteem te zoeken.
+    facet_key: coding_system
 
   - field_name: purpose
     label: Purpose
@@ -368,18 +416,31 @@ dataset_fields:
     validators: ignore_missing scheming_multiple_text
     help_text: >
       A category of the Dataset or tag describing the Dataset.
+    filter_help_text:
+      en: Use this filter to search datasets by health theme.
+      nl: Gebruik deze filter om datasets op gezondheidsthema te zoeken.
+    facet_key: health_theme
 
   - field_name: legal_basis
     label: Legal basis
     preset: multiple_text
     validators: ignore_missing scheming_multiple_text
     help_text: The legal basis used to justify processing of personal data.
+    filter_help_text:
+      en: Use this filter to search datasets by legal basis.
+      nl: Gebruik deze filter om datasets op rechtsgrondslag te zoeken.
+    facet_key: legal_basis
 
+  # Shared range facet used by discovery as typical_age.
   - field_name: min_typical_age
     label: Minimum typical age
     validators: ignore_missing int_validator
     form_snippet: number.html
     help_text: Minimum typical age of the population within the dataset.
+    filter_help_text:
+      en: Use this filter to search datasets by typical age.
+      nl: Gebruik deze filter om datasets op typische leeftijd te zoeken.
+    facet_key: typical_age
 
   - field_name: max_typical_age
     label: Maximum typical age
@@ -392,6 +453,10 @@ dataset_fields:
     validators: ignore_missing int_validator
     form_snippet: number.html
     help_text: Size of the dataset in terms of the number of records.
+    filter_help_text:
+      en: Use this filter to search datasets by number of records.
+      nl: Gebruik deze filter om datasets op aantal records te zoeken.
+    facet_key: number_of_records
 
   - field_name: number_of_unique_individuals
     label: Number of records for unique individuals.
@@ -404,6 +469,10 @@ dataset_fields:
     preset: multiple_text
     validators: ignore_missing scheming_multiple_text
     help_text: Key elements that represent an individual in the dataset.
+    filter_help_text:
+      en: Use this filter to search datasets by personal data elements.
+      nl: Gebruik deze filter om datasets op persoonsgegevens te zoeken.
+    facet_key: personal_data
 
   - field_name: publisher_note
     label: Publisher note

--- a/ckanext/gdi_userportal/scheming/schemas/dataset_multilingual.yaml
+++ b/ckanext/gdi_userportal/scheming/schemas/dataset_multilingual.yaml
@@ -19,7 +19,7 @@ dataset_fields:
     filter_help_text:
       en: Use this filter to search datasets by title.
       nl: Gebruik deze filter om datasets op titel te zoeken.
-    filter_key: title
+    facet_key: title
 
   - field_name: name
     label: URL

--- a/ckanext/gdi_userportal/scheming/schemas/dataset_series_multilingual.yaml
+++ b/ckanext/gdi_userportal/scheming/schemas/dataset_series_multilingual.yaml
@@ -14,7 +14,13 @@ dataset_fields:
       en: Title
       nl: Titel
     preset: fluent_core_translated
-    help_text: A descriptive title for the dataset series in each language.
+    help_text:
+      en: A descriptive title for the dataset series in each language.
+      nl: Een beschrijvende titel voor de datasetreeks in elke taal.
+    filter_help_text:
+      en: Use this filter to search dataset series by title.
+      nl: Gebruik deze filter om datasetreeksen op titel te zoeken.
+    facet_key: title
 
   - field_name: name
     label: URL

--- a/ckanext/gdi_userportal/scheming/schemas/dataset_series_multilingual.yaml
+++ b/ckanext/gdi_userportal/scheming/schemas/dataset_series_multilingual.yaml
@@ -69,6 +69,10 @@ dataset_fields:
       en: Frequency
       nl: Frequentie
     help_text: The frequency with which items are added to the dataset series collection.
+    filter_help_text:
+      en: Use this filter to search dataset series by frequency.
+      nl: Gebruik deze filter om datasetreeksen op frequentie te zoeken.
+    facet_key: frequency
 
   - field_name: spatial_coverage
     label: Spatial coverage
@@ -87,6 +91,10 @@ dataset_fields:
       nl: Wijzigingsdatum
     preset: datetime_flex
     help_text: Date on which the dataset series was changed.
+    filter_help_text:
+      en: Use this filter to search dataset series by modification date.
+      nl: Gebruik deze filter om datasetreeksen op wijzigingsdatum te zoeken.
+    facet_key: modified
 
   - field_name: publisher
     label: Publisher
@@ -138,6 +146,10 @@ dataset_fields:
       nl: Releasedatum
     preset: datetime_flex
     help_text: Date of formal issuance of the dataset series. This is the moment when the dataset series was established as a managed resource.
+    filter_help_text:
+      en: Use this filter to search dataset series by release date.
+      nl: Gebruik deze filter om datasetreeksen op releasedatum te zoeken.
+    facet_key: issued
 
   - field_name: temporal_coverage
     label: Temporal coverage

--- a/ckanext/gdi_userportal/tests/test_auth.py
+++ b/ckanext/gdi_userportal/tests/test_auth.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2026 Health-RI
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from ckanext.gdi_userportal.logic.auth.get import gdi_filter_help_texts_show
+from ckanext.gdi_userportal import plugin
+
+
+def test_get_auth_functions_exposes_filter_help_texts_action():
+    plugin_instance = plugin.GdiUserPortalPlugin()
+
+    auth_functions = plugin_instance.get_auth_functions()
+
+    assert auth_functions["gdi_filter_help_texts_show"] is gdi_filter_help_texts_show
+
+
+def test_filter_help_texts_auth_allows_access():
+    assert gdi_filter_help_texts_show(None, {}, {}) == {"success": True}

--- a/ckanext/gdi_userportal/tests/test_auth.py
+++ b/ckanext/gdi_userportal/tests/test_auth.py
@@ -15,4 +15,4 @@ def test_get_auth_functions_exposes_filter_help_texts_action():
 
 
 def test_filter_help_texts_auth_allows_access():
-    assert gdi_filter_help_texts_show(None, {}, {}) == {"success": True}
+    assert gdi_filter_help_texts_show({}, {}) == {"success": True}

--- a/ckanext/gdi_userportal/tests/test_filter_help_texts.py
+++ b/ckanext/gdi_userportal/tests/test_filter_help_texts.py
@@ -100,10 +100,13 @@ def test_gdi_filter_help_texts_show_empty_requested_keys_returns_no_keys(keys):
 
 
 def test_gdi_filter_help_texts_show_filters_requested_keys_from_list():
+    result = _call_action({"keys": ["title"]}, language="nl")
+
     assert result == {"title": "Gebruik deze filter om datasets op titel te zoeken."}
 
 
 def test_gdi_filter_help_texts_show_uses_requested_dataset_type():
+    schema_show = MagicMock(return_value=_schema())
 
     with patch(
         "ckanext.gdi_userportal.logic.action.get.toolkit.get_action",

--- a/ckanext/gdi_userportal/tests/test_filter_help_texts.py
+++ b/ckanext/gdi_userportal/tests/test_filter_help_texts.py
@@ -100,12 +100,10 @@ def test_gdi_filter_help_texts_show_empty_requested_keys_returns_no_keys(keys):
 
 
 def test_gdi_filter_help_texts_show_filters_requested_keys_from_list():
-    result = _call_action({"keys": ["title"]}, language="nl")
-
     assert result == {"title": "Gebruik deze filter om datasets op titel te zoeken."}
 
+
 def test_gdi_filter_help_texts_show_uses_requested_dataset_type():
-    schema_show = MagicMock(return_value=_schema())
 
     with patch(
         "ckanext.gdi_userportal.logic.action.get.toolkit.get_action",

--- a/ckanext/gdi_userportal/tests/test_filter_help_texts.py
+++ b/ckanext/gdi_userportal/tests/test_filter_help_texts.py
@@ -32,6 +32,25 @@ def _schema():
     }
 
 
+def _dataset_series_schema():
+    return {
+        "dataset_fields": [
+            {
+                "field_name": "title_translated",
+                "facet_key": "title",
+                "help_text": {
+                    "en": "A descriptive title for the dataset series in each language.",
+                    "nl": "Een beschrijvende titel voor de datasetreeks in elke taal.",
+                },
+                "filter_help_text": {
+                    "en": "Use this filter to search dataset series by title.",
+                    "nl": "Gebruik deze filter om datasetreeksen op titel te zoeken.",
+                },
+            }
+        ]
+    }
+
+
 def _call_action(data_dict=None, language="en"):
     schema_show = MagicMock(return_value=_schema())
 
@@ -92,3 +111,20 @@ def test_gdi_filter_help_texts_show_uses_requested_dataset_type():
         gdi_filter_help_texts_show({}, {"type": "dataset_series"})
 
     schema_show.assert_called_once_with({}, {"type": "dataset_series"})
+
+
+def test_gdi_filter_help_texts_show_returns_dataset_series_help_text():
+    schema_show = MagicMock(return_value=_dataset_series_schema())
+
+    with patch(
+        "ckanext.gdi_userportal.logic.action.get.toolkit.get_action",
+        return_value=schema_show,
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.get_request_language",
+        return_value="nl",
+    ):
+        result = gdi_filter_help_texts_show({}, {"type": "dataset_series"})
+
+    assert result == {
+        "title": "Gebruik deze filter om datasetreeksen op titel te zoeken."
+    }

--- a/ckanext/gdi_userportal/tests/test_filter_help_texts.py
+++ b/ckanext/gdi_userportal/tests/test_filter_help_texts.py
@@ -14,7 +14,7 @@ def _schema():
         "dataset_fields": [
             {
                 "field_name": "title_translated",
-                "filter_key": "title",
+                "facet_key": "title",
                 "help_text": {
                     "en": "A descriptive title for the dataset.",
                     "nl": "Een beschrijvende titel voor de dataset.",
@@ -26,7 +26,7 @@ def _schema():
             },
             {
                 "field_name": "theme",
-                "filter_key": "theme",
+                "facet_key": "theme",
             },
         ]
     }

--- a/ckanext/gdi_userportal/tests/test_filter_help_texts.py
+++ b/ckanext/gdi_userportal/tests/test_filter_help_texts.py
@@ -289,7 +289,7 @@ def test_gdi_filter_help_texts_show_parses_comma_separated_keys():
 
 
 def test_gdi_filter_help_texts_show_rejects_invalid_keys_type():
-    with pytest.raises(Exception):
+    with pytest.raises(action_get.toolkit.ValidationError):
         _call_action({"keys": 42})
 
 

--- a/ckanext/gdi_userportal/tests/test_filter_help_texts.py
+++ b/ckanext/gdi_userportal/tests/test_filter_help_texts.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2026 Health-RI
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ckanext.gdi_userportal.logic.action.get import gdi_filter_help_texts_show
+
+
+def _schema():
+    return {
+        "dataset_fields": [
+            {
+                "field_name": "title_translated",
+                "filter_key": "title",
+                "help_text": {
+                    "en": "A descriptive title for the dataset.",
+                    "nl": "Een beschrijvende titel voor de dataset.",
+                },
+                "filter_help_text": {
+                    "en": "Use this filter to search datasets by title.",
+                    "nl": "Gebruik deze filter om datasets op titel te zoeken.",
+                },
+            },
+            {
+                "field_name": "theme",
+                "filter_key": "theme",
+            },
+        ]
+    }
+
+
+def _call_action(data_dict=None, language="en"):
+    schema_show = MagicMock(return_value=_schema())
+
+    with patch(
+        "ckanext.gdi_userportal.logic.action.get.toolkit.get_action",
+        return_value=schema_show,
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.get_request_language",
+        return_value=language,
+    ):
+        result = gdi_filter_help_texts_show({}, data_dict or {})
+
+    schema_show.assert_called_once_with({}, {"type": "dataset"})
+    return result
+
+
+def test_gdi_filter_help_texts_show_returns_english_help_text():
+    result = _call_action(language="en")
+
+    assert result == {"title": "Use this filter to search datasets by title."}
+
+
+def test_gdi_filter_help_texts_show_returns_dutch_help_text():
+    result = _call_action(language="nl")
+
+    assert result == {"title": "Gebruik deze filter om datasets op titel te zoeken."}
+
+
+@pytest.mark.parametrize("language", [None, "", "de"])
+def test_gdi_filter_help_texts_show_falls_back_to_english(language):
+    result = _call_action(language=language)
+
+    assert result == {"title": "Use this filter to search datasets by title."}
+
+
+def test_gdi_filter_help_texts_show_filters_requested_keys_from_json_string():
+    result = _call_action({"keys": '["theme"]'})
+
+    assert result == {}
+
+
+def test_gdi_filter_help_texts_show_filters_requested_keys_from_list():
+    result = _call_action({"keys": ["title"]}, language="nl")
+
+    assert result == {"title": "Gebruik deze filter om datasets op titel te zoeken."}
+
+
+def test_gdi_filter_help_texts_show_uses_requested_dataset_type():
+    schema_show = MagicMock(return_value=_schema())
+
+    with patch(
+        "ckanext.gdi_userportal.logic.action.get.toolkit.get_action",
+        return_value=schema_show,
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.get_request_language",
+        return_value="en",
+    ):
+        gdi_filter_help_texts_show({}, {"type": "dataset_series"})
+
+    schema_show.assert_called_once_with({}, {"type": "dataset_series"})

--- a/ckanext/gdi_userportal/tests/test_filter_help_texts.py
+++ b/ckanext/gdi_userportal/tests/test_filter_help_texts.py
@@ -9,50 +9,169 @@ import pytest
 from ckanext.gdi_userportal.logic.action.get import gdi_filter_help_texts_show
 
 
-def _schema():
+DATASET_FILTER_CASES = [
+    (
+        "title_translated",
+        "title",
+        "Use this filter to search datasets by title.",
+        "Gebruik deze filter om datasets op titel te zoeken.",
+    ),
+    (
+        "tags_translated",
+        "tags",
+        "Use this filter to search datasets by keywords.",
+        "Gebruik deze filter om datasets op trefwoorden te zoeken.",
+    ),
+    (
+        "access_rights",
+        "access_rights",
+        "Use this filter to search datasets by access rights.",
+        "Gebruik deze filter om datasets op toegangsrechten te zoeken.",
+    ),
+    (
+        "alternate_identifier",
+        "alternate_identifier",
+        "Use this filter to search datasets by other identifiers.",
+        "Gebruik deze filter om datasets op andere identificatoren te zoeken.",
+    ),
+    (
+        "theme",
+        "theme",
+        "Use this filter to search datasets by theme.",
+        "Gebruik deze filter om datasets op thema te zoeken.",
+    ),
+    (
+        "language",
+        "language",
+        "Use this filter to search datasets by language.",
+        "Gebruik deze filter om datasets op taal te zoeken.",
+    ),
+    (
+        "conforms_to",
+        "conforms_to",
+        "Use this filter to search datasets by conformance specification.",
+        "Gebruik deze filter om datasets op specificatie te zoeken.",
+    ),
+    (
+        "is_referenced_by",
+        "is_referenced_by",
+        "Use this filter to search datasets by related references.",
+        "Gebruik deze filter om datasets op verwijzingen te zoeken.",
+    ),
+    (
+        "code_values",
+        "code_values",
+        "Use this filter to search datasets by code values.",
+        "Gebruik deze filter om datasets op codewaarden te zoeken.",
+    ),
+    (
+        "coding_system",
+        "coding_system",
+        "Use this filter to search datasets by coding system.",
+        "Gebruik deze filter om datasets op coderingssysteem te zoeken.",
+    ),
+    (
+        "health_theme",
+        "health_theme",
+        "Use this filter to search datasets by health theme.",
+        "Gebruik deze filter om datasets op gezondheidsthema te zoeken.",
+    ),
+    (
+        "legal_basis",
+        "legal_basis",
+        "Use this filter to search datasets by legal basis.",
+        "Gebruik deze filter om datasets op rechtsgrondslag te zoeken.",
+    ),
+    (
+        "min_typical_age",
+        "typical_age",
+        "Use this filter to search datasets by typical age.",
+        "Gebruik deze filter om datasets op typische leeftijd te zoeken.",
+    ),
+    (
+        "number_of_records",
+        "number_of_records",
+        "Use this filter to search datasets by number of records.",
+        "Gebruik deze filter om datasets op aantal records te zoeken.",
+    ),
+    (
+        "personal_data",
+        "personal_data",
+        "Use this filter to search datasets by personal data elements.",
+        "Gebruik deze filter om datasets op persoonsgegevens te zoeken.",
+    ),
+    (
+        "issued",
+        "issued",
+        "Use this filter to search datasets by release date.",
+        "Gebruik deze filter om datasets op releasedatum te zoeken.",
+    ),
+    (
+        "modified",
+        "modified",
+        "Use this filter to search datasets by modification date.",
+        "Gebruik deze filter om datasets op wijzigingsdatum te zoeken.",
+    ),
+    (
+        "frequency",
+        "frequency",
+        "Use this filter to search datasets by publication frequency.",
+        "Gebruik deze filter om datasets op publicatiefrequentie te zoeken.",
+    ),
+]
+
+DATASET_SERIES_FILTER_CASES = [
+    (
+        "title_translated",
+        "title",
+        "Use this filter to search dataset series by title.",
+        "Gebruik deze filter om datasetreeksen op titel te zoeken.",
+    ),
+    (
+        "frequency",
+        "frequency",
+        "Use this filter to search dataset series by frequency.",
+        "Gebruik deze filter om datasetreeksen op frequentie te zoeken.",
+    ),
+    (
+        "modified",
+        "modified",
+        "Use this filter to search dataset series by modification date.",
+        "Gebruik deze filter om datasetreeksen op wijzigingsdatum te zoeken.",
+    ),
+    (
+        "issued",
+        "issued",
+        "Use this filter to search dataset series by release date.",
+        "Gebruik deze filter om datasetreeksen op releasedatum te zoeken.",
+    ),
+]
+
+
+def _schema(cases=DATASET_FILTER_CASES):
     return {
         "dataset_fields": [
             {
-                "field_name": "title_translated",
-                "facet_key": "title",
-                "help_text": {
-                    "en": "A descriptive title for the dataset.",
-                    "nl": "Een beschrijvende titel voor de dataset.",
-                },
+                "field_name": field_name,
+                "facet_key": facet_key,
                 "filter_help_text": {
-                    "en": "Use this filter to search datasets by title.",
-                    "nl": "Gebruik deze filter om datasets op titel te zoeken.",
+                    "en": help_text_en,
+                    "nl": help_text_nl,
                 },
-            },
-            {
-                "field_name": "theme",
-                "facet_key": "theme",
-            },
+            }
+            for field_name, facet_key, help_text_en, help_text_nl in cases
         ]
     }
 
 
 def _dataset_series_schema():
-    return {
-        "dataset_fields": [
-            {
-                "field_name": "title_translated",
-                "facet_key": "title",
-                "help_text": {
-                    "en": "A descriptive title for the dataset series in each language.",
-                    "nl": "Een beschrijvende titel voor de datasetreeks in elke taal.",
-                },
-                "filter_help_text": {
-                    "en": "Use this filter to search dataset series by title.",
-                    "nl": "Gebruik deze filter om datasetreeksen op titel te zoeken.",
-                },
-            }
-        ]
-    }
+    return _schema(DATASET_SERIES_FILTER_CASES)
 
 
-def _call_action(data_dict=None, language="en"):
-    schema_show = MagicMock(return_value=_schema())
+def _call_action(data_dict=None, language="en", schema=None):
+    schema_show = MagicMock(return_value=schema or _schema())
+    request_data = data_dict or {}
+    dataset_type = request_data.get("type", "dataset")
 
     with patch(
         "ckanext.gdi_userportal.logic.action.get.toolkit.get_action",
@@ -61,35 +180,58 @@ def _call_action(data_dict=None, language="en"):
         "ckanext.gdi_userportal.logic.action.get.get_request_language",
         return_value=language,
     ):
-        result = gdi_filter_help_texts_show({}, data_dict or {})
+        result = gdi_filter_help_texts_show({}, request_data)
 
-    schema_show.assert_called_once_with({}, {"type": "dataset"})
+    schema_show.assert_called_once_with({}, {"type": dataset_type})
     return result
 
 
-def test_gdi_filter_help_texts_show_returns_english_help_text():
-    result = _call_action(language="en")
+@pytest.mark.parametrize("field_name, facet_key, expected_en, expected_nl", DATASET_FILTER_CASES)
+@pytest.mark.parametrize("language", ["en", "nl"])
+def test_gdi_filter_help_texts_show_returns_dataset_help_texts(
+    field_name, facet_key, expected_en, expected_nl, language
+):
+    expected = expected_en if language == "en" else expected_nl
 
-    assert result == {"title": "Use this filter to search datasets by title."}
+    result = _call_action({"keys": [facet_key]}, language=language)
+
+    assert result == {facet_key: expected}
 
 
-def test_gdi_filter_help_texts_show_returns_dutch_help_text():
-    result = _call_action(language="nl")
+@pytest.mark.parametrize(
+    "field_name, facet_key, expected_en, expected_nl",
+    DATASET_SERIES_FILTER_CASES,
+)
+@pytest.mark.parametrize("language", ["en", "nl"])
+def test_gdi_filter_help_texts_show_returns_dataset_series_help_texts(
+    field_name, facet_key, expected_en, expected_nl, language
+):
+    expected = expected_en if language == "en" else expected_nl
 
-    assert result == {"title": "Gebruik deze filter om datasets op titel te zoeken."}
+    result = _call_action(
+        {"type": "dataset_series", "keys": [facet_key]},
+        language=language,
+        schema=_dataset_series_schema(),
+    )
+
+    assert result == {facet_key: expected}
 
 
 @pytest.mark.parametrize("language", [None, "", "de"])
 def test_gdi_filter_help_texts_show_falls_back_to_english(language):
-    result = _call_action(language=language)
+    result = _call_action({"keys": ["theme"]}, language=language)
 
-    assert result == {"title": "Use this filter to search datasets by title."}
+    assert result == {
+        "theme": "Use this filter to search datasets by theme.",
+    }
 
 
 def test_gdi_filter_help_texts_show_filters_requested_keys_from_json_string():
-    result = _call_action({"keys": '["theme"]'})
+    result = _call_action({"keys": '["theme", "unknown"]'})
 
-    assert result == {}
+    assert result == {
+        "theme": "Use this filter to search datasets by theme.",
+    }
 
 
 @pytest.mark.parametrize("keys", ["[]", [], ["   "], [None]])
@@ -99,14 +241,8 @@ def test_gdi_filter_help_texts_show_empty_requested_keys_returns_no_keys(keys):
     assert result == {}
 
 
-def test_gdi_filter_help_texts_show_filters_requested_keys_from_list():
-    result = _call_action({"keys": ["title"]}, language="nl")
-
-    assert result == {"title": "Gebruik deze filter om datasets op titel te zoeken."}
-
-
 def test_gdi_filter_help_texts_show_uses_requested_dataset_type():
-    schema_show = MagicMock(return_value=_schema())
+    schema_show = MagicMock(return_value=_dataset_series_schema())
 
     with patch(
         "ckanext.gdi_userportal.logic.action.get.toolkit.get_action",
@@ -118,20 +254,3 @@ def test_gdi_filter_help_texts_show_uses_requested_dataset_type():
         gdi_filter_help_texts_show({}, {"type": "dataset_series"})
 
     schema_show.assert_called_once_with({}, {"type": "dataset_series"})
-
-
-def test_gdi_filter_help_texts_show_returns_dataset_series_help_text():
-    schema_show = MagicMock(return_value=_dataset_series_schema())
-
-    with patch(
-        "ckanext.gdi_userportal.logic.action.get.toolkit.get_action",
-        return_value=schema_show,
-    ), patch(
-        "ckanext.gdi_userportal.logic.action.get.get_request_language",
-        return_value="nl",
-    ):
-        result = gdi_filter_help_texts_show({}, {"type": "dataset_series"})
-
-    assert result == {
-        "title": "Gebruik deze filter om datasetreeksen op titel te zoeken."
-    }

--- a/ckanext/gdi_userportal/tests/test_filter_help_texts.py
+++ b/ckanext/gdi_userportal/tests/test_filter_help_texts.py
@@ -92,11 +92,17 @@ def test_gdi_filter_help_texts_show_filters_requested_keys_from_json_string():
     assert result == {}
 
 
+@pytest.mark.parametrize("keys", ["[]", [], ["   "], [None]])
+def test_gdi_filter_help_texts_show_empty_requested_keys_returns_no_keys(keys):
+    result = _call_action({"keys": keys})
+
+    assert result == {}
+
+
 def test_gdi_filter_help_texts_show_filters_requested_keys_from_list():
     result = _call_action({"keys": ["title"]}, language="nl")
 
     assert result == {"title": "Gebruik deze filter om datasets op titel te zoeken."}
-
 
 def test_gdi_filter_help_texts_show_uses_requested_dataset_type():
     schema_show = MagicMock(return_value=_schema())

--- a/ckanext/gdi_userportal/tests/test_filter_help_texts.py
+++ b/ckanext/gdi_userportal/tests/test_filter_help_texts.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from ckanext.gdi_userportal.logic.action import get as action_get
 from ckanext.gdi_userportal.logic.action.get import gdi_filter_help_texts_show
 
 
@@ -168,6 +169,22 @@ def _dataset_series_schema():
     return _schema(DATASET_SERIES_FILTER_CASES)
 
 
+def _fallback_schema():
+    return {
+        "dataset_fields": [
+            {
+                "field_name": "fallback_title",
+                "facet_key": "fallback_title",
+                "help_text": "Fallback help text.",
+            },
+            {
+                "field_name": "hidden_field",
+                "facet_key": "hidden_field",
+            },
+        ]
+    }
+
+
 def _call_action(data_dict=None, language="en", schema=None):
     schema_show = MagicMock(return_value=schema or _schema())
     request_data = data_dict or {}
@@ -254,3 +271,127 @@ def test_gdi_filter_help_texts_show_uses_requested_dataset_type():
         gdi_filter_help_texts_show({}, {"type": "dataset_series"})
 
     schema_show.assert_called_once_with({}, {"type": "dataset_series"})
+
+
+def test_gdi_filter_help_texts_show_uses_help_text_when_filter_help_text_missing():
+    result = _call_action(schema=_fallback_schema())
+
+    assert result == {"fallback_title": "Fallback help text."}
+
+
+def test_gdi_filter_help_texts_show_parses_comma_separated_keys():
+    result = _call_action({"keys": "theme, access_rights"})
+
+    assert result == {
+        "theme": "Use this filter to search datasets by theme.",
+        "access_rights": "Use this filter to search datasets by access rights.",
+    }
+
+
+def test_gdi_filter_help_texts_show_rejects_invalid_keys_type():
+    with pytest.raises(Exception):
+        _call_action({"keys": 42})
+
+
+def test_enhanced_package_search_replaces_results_and_facets():
+    response = {
+        "results": [{"name": "dataset-1"}],
+        "search_facets": {"theme": {"title": "Theme"}},
+    }
+
+    package_search = MagicMock(return_value=response)
+
+    with patch(
+        "ckanext.gdi_userportal.logic.action.get.toolkit.get_action",
+        side_effect=lambda name: package_search if name == "package_search" else None,
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.collect_values_to_translate",
+        return_value=["alpha"],
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.get_request_language",
+        return_value="nl",
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.get_translations",
+        return_value={"alpha": "beta"},
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.replace_package",
+        side_effect=lambda package, translations, lang=None: {
+            **package,
+            "translated_lang": lang,
+            "translated_values": translations,
+        },
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.replace_search_facets",
+        return_value={"theme": {"title": "Vertaling"}},
+    ) as replace_search_facets:
+        result = action_get.enhanced_package_search({}, {"rows": 0})
+
+    assert result["results"] == [
+        {
+            "name": "dataset-1",
+            "translated_lang": "nl",
+            "translated_values": {"alpha": "beta"},
+        }
+    ]
+    assert result["search_facets"] == {"theme": {"title": "Vertaling"}}
+    replace_search_facets.assert_called_once()
+
+
+def test_enhanced_package_search_leaves_results_without_search_facets():
+    response = {"results": [{"name": "dataset-1"}]}
+
+    package_search = MagicMock(return_value=response)
+
+    with patch(
+        "ckanext.gdi_userportal.logic.action.get.toolkit.get_action",
+        side_effect=lambda name: package_search if name == "package_search" else None,
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.collect_values_to_translate",
+        return_value=["alpha"],
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.get_request_language",
+        return_value="en",
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.get_translations",
+        return_value={"alpha": "beta"},
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.replace_package",
+        side_effect=lambda package, translations, lang=None: {
+            **package,
+            "translated_lang": lang,
+        },
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.replace_search_facets"
+    ) as replace_search_facets:
+        result = action_get.enhanced_package_search({}, {"rows": 0})
+
+    assert result["results"] == [{"name": "dataset-1", "translated_lang": "en"}]
+    assert "search_facets" not in result
+    replace_search_facets.assert_not_called()
+
+
+def test_enhanced_package_show_replaces_package():
+    response = {"name": "dataset-1"}
+
+    package_show = MagicMock(return_value=response)
+
+    with patch(
+        "ckanext.gdi_userportal.logic.action.get.toolkit.get_action",
+        side_effect=lambda name: package_show if name == "package_show" else None,
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.collect_values_to_translate",
+        return_value=["alpha"],
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.get_request_language",
+        return_value="en",
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.get_translations",
+        return_value={"alpha": "beta"},
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.replace_package",
+        return_value={"name": "dataset-1", "translated": True},
+    ) as replace_package:
+        result = action_get.enhanced_package_show({}, {"id": "dataset-1"})
+
+    assert result == {"name": "dataset-1", "translated": True}
+    replace_package.assert_called_once()


### PR DESCRIPTION
## Summary\n- add multilingual scheming metadata for the title filter help text\n- expose gdi_filter_help_texts_show and reuse shared request-language handling\n- keep package/show responses unchanged\n\n## Notes\n- filter help text is sourced from scheming metadata\n- package show remains out of scope

## Summary by Sourcery

Add multilingual, schema-driven filter help texts for dataset and dataset series facets and expose them via a new public action while reusing shared language preference handling.

New Features:
- Introduce schema-level multilingual filter_help_text and facet_key metadata for dataset and dataset series fields used as facets.
- Add gdi_filter_help_texts_show action to return localized filter help texts based on scheming metadata and request language.
- Expose the gdi_filter_help_texts_show action and auth entry so it is available to anonymous clients and plugins.

Enhancements:
- Refactor language handling to centralize request language retrieval and preferred-language selection and reuse it in translation-related actions.
- Ensure enhanced_package_search and enhanced_package_show reuse shared language utilities without changing their external responses.

Tests:
- Add unit tests covering gdi_filter_help_texts_show behavior, including language fallback, dataset type switching, key filtering, and invalid input handling.
- Extend tests for enhanced_package_search and enhanced_package_show to verify facet translation behavior and unchanged responses when facets are absent.
- Add tests to ensure auth wiring exposes the new filter help texts action and allows anonymous access.