### PR TITLE
Add dataset detail help text endpoint

### DIFF
--- a/ckanext/gdi_userportal/logic/action/get.py
+++ b/ckanext/gdi_userportal/logic/action/get.py
@@ -57,19 +57,63 @@ def gdi_filter_help_texts_show(context, data_dict=None) -> Dict[str, str]:
         context, {"type": dataset_type}
     )
 
+    return _collect_help_texts(
+        schema,
+        "facet_key",
+        ("filter_help_text", "help_text"),
+        requested_keys,
+        language,
+    )
+
+
+@toolkit.side_effect_free
+def gdi_dataset_help_texts_show(context, data_dict=None) -> Dict[str, str]:
+    data_dict = data_dict or {}
+    dataset_type = data_dict.get("type", "dataset")
+    requested_keys = _parse_requested_keys(data_dict.get("keys"))
+    language = get_preferred_language(get_request_language())
+
+    schema = toolkit.get_action("scheming_dataset_schema_show")(
+        context, {"type": dataset_type}
+    )
+
+    return _collect_help_texts(
+        schema,
+        "field_name",
+        ("help_text",),
+        requested_keys,
+        language,
+    )
+
+
+def _collect_help_texts(
+    schema: Dict[str, Any],
+    key_property: str,
+    text_properties: tuple[str, ...],
+    requested_keys: Optional[Set[str]],
+    language: str,
+) -> Dict[str, str]:
     help_texts = {}
     for field in schema.get("dataset_fields", []):
-        facet_key = field.get("facet_key")
-        if not facet_key or (requested_keys is not None and facet_key not in requested_keys):
+        key = field.get(key_property)
+        if not key or (requested_keys is not None and key not in requested_keys):
             continue
 
-        help_text = _localized_text(
-            field.get("filter_help_text") or field.get("help_text"), language
-        )
+        help_text = _first_localized_text(field, text_properties, language)
         if help_text:
-            help_texts[facet_key] = help_text
+            help_texts[key] = help_text
 
     return help_texts
+
+
+def _first_localized_text(
+    field: Dict[str, Any], text_properties: tuple[str, ...], language: str
+) -> str:
+    for text_property in text_properties:
+        help_text = _localized_text(field.get(text_property), language)
+        if help_text:
+            return help_text
+    return ""
 
 
 def _parse_requested_keys(keys: Any) -> Optional[Set[str]]:

--- a/ckanext/gdi_userportal/logic/action/get.py
+++ b/ckanext/gdi_userportal/logic/action/get.py
@@ -100,7 +100,7 @@ def _collect_help_texts(
             continue
 
         help_text = _first_localized_text(field, text_properties, language)
-        if help_text:
+        if help_text is not None:
             help_texts[key] = help_text
 
     return help_texts
@@ -108,12 +108,12 @@ def _collect_help_texts(
 
 def _first_localized_text(
     field: Dict[str, Any], text_properties: Tuple[str, ...], language: str
-) -> str:
+) -> Optional[str]:
     for text_property in text_properties:
         help_text = _localized_text(field.get(text_property), language)
         if help_text:
             return help_text
-    return ""
+    return None
 
 
 def _parse_requested_keys(keys: Any) -> Optional[Set[str]]:

--- a/ckanext/gdi_userportal/logic/action/get.py
+++ b/ckanext/gdi_userportal/logic/action/get.py
@@ -8,7 +8,6 @@
 # -*- coding: utf-8 -*-
 
 import json
-from typing import Any, Dict, Optional, Set, Tuple
 
 from ckan.plugins import toolkit
 from ckanext.gdi_userportal.logic.action.translation_utils import (
@@ -22,7 +21,7 @@ from ckanext.gdi_userportal.logic.action.translation_utils import (
 
 
 @toolkit.side_effect_free
-def enhanced_package_search(context, data_dict) -> Dict:
+def enhanced_package_search(context, data_dict) -> dict:
     result = toolkit.get_action("package_search")(context, data_dict)
     values_to_translate = collect_values_to_translate(result)
     lang = get_request_language()
@@ -39,7 +38,7 @@ def enhanced_package_search(context, data_dict) -> Dict:
 
 
 @toolkit.side_effect_free
-def enhanced_package_show(context, data_dict) -> Dict:
+def enhanced_package_show(context, data_dict) -> dict:
     result = toolkit.get_action("package_show")(context, data_dict)
     values_to_translate = collect_values_to_translate(result)
     lang = get_request_language()
@@ -48,7 +47,7 @@ def enhanced_package_show(context, data_dict) -> Dict:
 
 
 @toolkit.side_effect_free
-def gdi_filter_help_texts_show(context, data_dict=None) -> Dict[str, str]:
+def gdi_filter_help_texts_show(context, data_dict=None) -> dict[str, str]:
     data_dict = data_dict or {}
     dataset_type = data_dict.get("type", "dataset")
     requested_keys = _parse_requested_keys(data_dict.get("keys"))
@@ -68,7 +67,7 @@ def gdi_filter_help_texts_show(context, data_dict=None) -> Dict[str, str]:
 
 
 @toolkit.side_effect_free
-def gdi_dataset_help_texts_show(context, data_dict=None) -> Dict[str, str]:
+def gdi_dataset_help_texts_show(context, data_dict=None) -> dict[str, str]:
     data_dict = data_dict or {}
     dataset_type = data_dict.get("type", "dataset")
     requested_keys = _parse_requested_keys(data_dict.get("keys"))
@@ -88,12 +87,12 @@ def gdi_dataset_help_texts_show(context, data_dict=None) -> Dict[str, str]:
 
 
 def _collect_help_texts(
-    schema: Dict[str, Any],
+    schema: dict[str, object],
     key_property: str,
-    text_properties: Tuple[str, ...],
-    requested_keys: Optional[Set[str]],
+    text_properties: tuple[str, ...],
+    requested_keys: set[str] | None,
     language: str,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     help_texts = {}
     for field in schema.get("dataset_fields", []):
         key = field.get(key_property)
@@ -108,8 +107,8 @@ def _collect_help_texts(
 
 
 def _first_localized_text(
-    field: Dict[str, Any], text_properties: Tuple[str, ...], language: str
-) -> Optional[str]:
+    field: dict[str, object], text_properties: tuple[str, ...], language: str
+) -> str | None:
     for text_property in text_properties:
         help_text = _localized_text(field.get(text_property), language)
         if help_text:
@@ -117,7 +116,7 @@ def _first_localized_text(
     return None
 
 
-def _parse_requested_keys(keys: Any) -> Optional[Set[str]]:
+def _parse_requested_keys(keys: object) -> set[str] | None:
     if keys is None or keys == "":
         return None
 
@@ -134,7 +133,7 @@ def _parse_requested_keys(keys: Any) -> Optional[Set[str]]:
     return parsed_keys
 
 
-def _localized_text(value: Any, language: str) -> str:
+def _localized_text(value: object, language: str) -> str:
     if isinstance(value, dict):
         return value.get(language) or value.get("en") or ""
 

--- a/ckanext/gdi_userportal/logic/action/get.py
+++ b/ckanext/gdi_userportal/logic/action/get.py
@@ -8,6 +8,8 @@
 # -*- coding: utf-8 -*-
 
 import json
+from typing import Any, Dict, Optional, Set, Tuple
+
 from ckan.plugins import toolkit
 from ckanext.gdi_userportal.logic.action.translation_utils import (
     collect_values_to_translate,
@@ -17,7 +19,6 @@ from ckanext.gdi_userportal.logic.action.translation_utils import (
     replace_package,
     replace_search_facets,
 )
-from typing import Any, Dict, Optional, Set, Tuple
 
 
 @toolkit.side_effect_free

--- a/ckanext/gdi_userportal/logic/action/get.py
+++ b/ckanext/gdi_userportal/logic/action/get.py
@@ -17,7 +17,7 @@ from ckanext.gdi_userportal.logic.action.translation_utils import (
     replace_package,
     replace_search_facets,
 )
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, Optional, Set, Tuple
 
 
 @toolkit.side_effect_free
@@ -89,7 +89,7 @@ def gdi_dataset_help_texts_show(context, data_dict=None) -> Dict[str, str]:
 def _collect_help_texts(
     schema: Dict[str, Any],
     key_property: str,
-    text_properties: tuple[str, ...],
+    text_properties: Tuple[str, ...],
     requested_keys: Optional[Set[str]],
     language: str,
 ) -> Dict[str, str]:
@@ -107,7 +107,7 @@ def _collect_help_texts(
 
 
 def _first_localized_text(
-    field: Dict[str, Any], text_properties: tuple[str, ...], language: str
+    field: Dict[str, Any], text_properties: Tuple[str, ...], language: str
 ) -> str:
     for text_property in text_properties:
         help_text = _localized_text(field.get(text_property), language)

--- a/ckanext/gdi_userportal/logic/auth/get.py
+++ b/ckanext/gdi_userportal/logic/auth/get.py
@@ -25,3 +25,8 @@ def config_option_show(next_auth, context, data_dict=None):
 @toolkit.auth_allow_anonymous_access
 def gdi_filter_help_texts_show(context, data_dict=None):
     return {"success": True}
+
+
+@toolkit.auth_allow_anonymous_access
+def gdi_dataset_help_texts_show(context, data_dict=None):
+    return {"success": True}

--- a/ckanext/gdi_userportal/plugin.py
+++ b/ckanext/gdi_userportal/plugin.py
@@ -14,12 +14,14 @@ from ckanext.gdi_userportal.logic.action.translation_utils import (
     _deduplicate_non_empty_strings,
 )
 from ckanext.gdi_userportal.logic.action.get import (
+    gdi_dataset_help_texts_show,
     enhanced_package_search,
     enhanced_package_show,
     gdi_filter_help_texts_show,
 )
 from ckanext.gdi_userportal.logic.auth.get import (
     config_option_show,
+    gdi_dataset_help_texts_show as gdi_dataset_help_texts_show_auth,
     gdi_filter_help_texts_show as gdi_filter_help_texts_show_auth,
 )
 from ckanext.gdi_userportal.validation import scheming_isodatetime_flex
@@ -160,6 +162,7 @@ class GdiUserPortalPlugin(plugins.SingletonPlugin):
     def get_auth_functions(self):
         return {
             "config_option_show": config_option_show,
+            "gdi_dataset_help_texts_show": gdi_dataset_help_texts_show_auth,
             "gdi_filter_help_texts_show": gdi_filter_help_texts_show_auth,
         }
 
@@ -167,6 +170,7 @@ class GdiUserPortalPlugin(plugins.SingletonPlugin):
         return {
             "enhanced_package_search": enhanced_package_search,
             "enhanced_package_show": enhanced_package_show,
+            "gdi_dataset_help_texts_show": gdi_dataset_help_texts_show,
             "gdi_filter_help_texts_show": gdi_filter_help_texts_show,
         }
 

--- a/ckanext/gdi_userportal/tests/test_auth.py
+++ b/ckanext/gdi_userportal/tests/test_auth.py
@@ -2,7 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ckanext.gdi_userportal.logic.auth.get import gdi_filter_help_texts_show
+from ckanext.gdi_userportal.logic.auth.get import (
+    gdi_dataset_help_texts_show,
+    gdi_filter_help_texts_show,
+)
 from ckanext.gdi_userportal import plugin
 
 
@@ -12,7 +15,12 @@ def test_get_auth_functions_exposes_filter_help_texts_action():
     auth_functions = plugin_instance.get_auth_functions()
 
     assert auth_functions["gdi_filter_help_texts_show"] is gdi_filter_help_texts_show
+    assert auth_functions["gdi_dataset_help_texts_show"] is gdi_dataset_help_texts_show
 
 
 def test_filter_help_texts_auth_allows_access():
     assert gdi_filter_help_texts_show({}, {}) == {"success": True}
+
+
+def test_dataset_help_texts_auth_allows_access():
+    assert gdi_dataset_help_texts_show({}, {}) == {"success": True}

--- a/ckanext/gdi_userportal/tests/test_filter_help_texts.py
+++ b/ckanext/gdi_userportal/tests/test_filter_help_texts.py
@@ -7,7 +7,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ckanext.gdi_userportal.logic.action import get as action_get
-from ckanext.gdi_userportal.logic.action.get import gdi_filter_help_texts_show
+from ckanext.gdi_userportal.logic.action.get import (
+    gdi_dataset_help_texts_show,
+    gdi_filter_help_texts_show,
+)
 
 
 DATASET_FILTER_CASES = [
@@ -185,6 +188,52 @@ def _fallback_schema():
     }
 
 
+def _dataset_help_text_schema():
+    return {
+        "dataset_fields": [
+            {
+                "field_name": "title_translated",
+                "facet_key": "title",
+                "help_text": {
+                    "en": "A descriptive title for the dataset.",
+                    "nl": "Een beschrijvende titel voor de dataset.",
+                },
+                "filter_help_text": {
+                    "en": "Use this filter to search datasets by title.",
+                    "nl": "Gebruik deze filter om datasets op titel te zoeken.",
+                },
+            },
+            {
+                "field_name": "access_rights",
+                "facet_key": "access_rights",
+                "help_text": {
+                    "en": "Information that indicates whether the dataset is open or restricted.",
+                    "nl": "Informatie die aangeeft of de dataset open of beperkt toegankelijk is.",
+                },
+            },
+            {
+                "field_name": "hidden_field",
+                "facet_key": "hidden_field",
+            },
+        ]
+    }
+
+
+def _dataset_series_help_text_schema():
+    return {
+        "dataset_fields": [
+            {
+                "field_name": "title_translated",
+                "facet_key": "title",
+                "help_text": {
+                    "en": "A descriptive title for the dataset series.",
+                    "nl": "Een beschrijvende titel voor de datasetreeks.",
+                },
+            },
+        ]
+    }
+
+
 def _call_action(data_dict=None, language="en", schema=None):
     schema_show = MagicMock(return_value=schema or _schema())
     request_data = data_dict or {}
@@ -198,6 +247,24 @@ def _call_action(data_dict=None, language="en", schema=None):
         return_value=language,
     ):
         result = gdi_filter_help_texts_show({}, request_data)
+
+    schema_show.assert_called_once_with({}, {"type": dataset_type})
+    return result
+
+
+def _call_dataset_action(data_dict=None, language="en", schema=None):
+    schema_show = MagicMock(return_value=schema or _dataset_help_text_schema())
+    request_data = data_dict or {}
+    dataset_type = request_data.get("type", "dataset")
+
+    with patch(
+        "ckanext.gdi_userportal.logic.action.get.toolkit.get_action",
+        return_value=schema_show,
+    ), patch(
+        "ckanext.gdi_userportal.logic.action.get.get_request_language",
+        return_value=language,
+    ):
+        result = gdi_dataset_help_texts_show({}, request_data)
 
     schema_show.assert_called_once_with({}, {"type": dataset_type})
     return result
@@ -291,6 +358,69 @@ def test_gdi_filter_help_texts_show_parses_comma_separated_keys():
 def test_gdi_filter_help_texts_show_rejects_invalid_keys_type():
     with pytest.raises(Exception):
         _call_action({"keys": 42})
+
+
+@pytest.mark.parametrize(
+    "language, expected",
+    [
+        ("en", "A descriptive title for the dataset."),
+        ("nl", "Een beschrijvende titel voor de dataset."),
+    ],
+)
+def test_gdi_dataset_help_texts_show_returns_localized_help_text(language, expected):
+    result = _call_dataset_action({"keys": ["title_translated"]}, language=language)
+
+    assert result == {"title_translated": expected}
+
+
+@pytest.mark.parametrize("language", [None, "", "de"])
+def test_gdi_dataset_help_texts_show_falls_back_to_english(language):
+    result = _call_dataset_action({"keys": ["title_translated"]}, language=language)
+
+    assert result == {"title_translated": "A descriptive title for the dataset."}
+
+
+def test_gdi_dataset_help_texts_show_filters_requested_keys_from_json_string():
+    result = _call_dataset_action({"keys": '["access_rights", "unknown"]'})
+
+    assert result == {
+        "access_rights": "Information that indicates whether the dataset is open or restricted.",
+    }
+
+
+@pytest.mark.parametrize("keys", ["[]", [], ["   "], [None]])
+def test_gdi_dataset_help_texts_show_empty_requested_keys_returns_no_keys(keys):
+    result = _call_dataset_action({"keys": keys})
+
+    assert result == {}
+
+
+def test_gdi_dataset_help_texts_show_uses_requested_dataset_type():
+    result = _call_dataset_action(
+        {"type": "dataset_series", "keys": ["title_translated"]},
+        schema=_dataset_series_help_text_schema(),
+    )
+
+    assert result == {"title_translated": "A descriptive title for the dataset series."}
+
+
+def test_gdi_dataset_help_texts_show_omits_fields_without_help_text():
+    result = _call_dataset_action({"keys": "hidden_field, access_rights"})
+
+    assert result == {
+        "access_rights": "Information that indicates whether the dataset is open or restricted.",
+    }
+
+
+def test_gdi_dataset_help_texts_show_uses_help_text_not_filter_help_text():
+    result = _call_dataset_action({"keys": ["title_translated"]})
+
+    assert result == {"title_translated": "A descriptive title for the dataset."}
+
+
+def test_gdi_dataset_help_texts_show_rejects_invalid_keys_type():
+    with pytest.raises(Exception):
+        _call_dataset_action({"keys": 42})
 
 
 def test_enhanced_package_search_replaces_results_and_facets():


### PR DESCRIPTION
## Summary
- add `gdi_dataset_help_texts_show` to expose localized scheming `help_text` by field name
- register anonymous auth and action wiring for the new endpoint
- keep filter help text behavior separate, including `filter_help_text` preference

## Validation
- `docker compose exec -T ckan-dev sh -lc "cd /srv/app/src_extensions/ckanext-gdi-userportal && pytest --cov=ckanext.gdi_userportal --cov-report=term-missing --cov-branch ckanext/gdi_userportal/tests/test_filter_help_texts.py ckanext/gdi_userportal/tests/test_auth.py"`

## Summary by Sourcery

Add an anonymous, side-effect-free endpoint to retrieve localized dataset field help text and reuse shared logic for collecting help texts.

New Features:
- Expose a gdi_dataset_help_texts_show action to return localized dataset help text by field name for a given dataset type.

Enhancements:
- Refactor help text collection into a shared utility to support both filter-specific and general dataset help texts.
- Wire the new dataset help texts action and auth handlers into the plugin’s action and auth registries.

Tests:
- Add unit tests covering the new dataset help texts endpoint, including localization, dataset-type handling, key parsing, and exclusion of fields without help text.
- Extend auth tests to verify exposure and anonymous access for the new dataset help texts action.