### PR TITLE
Normalize multiline help text values

### DIFF
--- a/ckanext/gdi_userportal/logic/action/get.py
+++ b/ckanext/gdi_userportal/logic/action/get.py
@@ -135,9 +135,16 @@ def _parse_requested_keys(keys: object) -> set[str] | None:
 
 def _localized_text(value: object, language: str) -> str:
     if isinstance(value, dict):
-        return value.get(language) or value.get("en") or ""
+        return _normalize_help_text(value.get(language) or value.get("en") or "")
 
     if isinstance(value, str):
-        return value
+        return _normalize_help_text(value)
 
     return ""
+
+
+def _normalize_help_text(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+
+    return " ".join(value.split())

--- a/ckanext/gdi_userportal/tests/test_filter_help_texts.py
+++ b/ckanext/gdi_userportal/tests/test_filter_help_texts.py
@@ -346,6 +346,26 @@ def test_gdi_filter_help_texts_show_uses_help_text_when_filter_help_text_missing
     assert result == {"fallback_title": "Fallback help text."}
 
 
+def test_gdi_filter_help_texts_show_normalizes_multiline_help_text():
+    schema = {
+        "dataset_fields": [
+            {
+                "field_name": "health_theme",
+                "facet_key": "health_theme",
+                "filter_help_text": {
+                    "en": "A category of the Dataset\nor tag describing the Dataset.\n",
+                },
+            },
+        ]
+    }
+
+    result = _call_action({"keys": ["health_theme"]}, schema=schema)
+
+    assert result == {
+        "health_theme": "A category of the Dataset or tag describing the Dataset.",
+    }
+
+
 def test_gdi_filter_help_texts_show_parses_comma_separated_keys():
     result = _call_action({"keys": "theme, access_rights"})
 
@@ -416,6 +436,25 @@ def test_gdi_dataset_help_texts_show_uses_help_text_not_filter_help_text():
     result = _call_dataset_action({"keys": ["title_translated"]})
 
     assert result == {"title_translated": "A descriptive title for the dataset."}
+
+
+def test_gdi_dataset_help_texts_show_normalizes_multiline_help_text():
+    schema = {
+        "dataset_fields": [
+            {
+                "field_name": "health_theme",
+                "help_text": {
+                    "en": "A category of the Dataset\nor tag describing the Dataset.\n",
+                },
+            },
+        ]
+    }
+
+    result = _call_dataset_action({"keys": ["health_theme"]}, schema=schema)
+
+    assert result == {
+        "health_theme": "A category of the Dataset or tag describing the Dataset.",
+    }
 
 
 def test_gdi_dataset_help_texts_show_rejects_invalid_keys_type():


### PR DESCRIPTION
## Summary
- Normalize help text values returned by the CKAN help-text actions by collapsing embedded whitespace and trimming trailing newlines.
- Add coverage for multiline filter and dataset help text values, including the health_theme style YAML block.

## Validation
- python -m py_compile ckanext/gdi_userportal/logic/action/get.py ckanext/gdi_userportal/tests/test_filter_help_texts.py
- pytest --disable-warnings ckanext/gdi_userportal/tests/test_filter_help_texts.py (blocked locally: CKAN module is not installed in the host Python environment)

## Summary by Sourcery

Normalize localized help text values returned by help-text actions to collapse embedded whitespace and trim trailing newlines.

Bug Fixes:
- Ensure help text values are consistently normalized regardless of whether they are provided as localized dicts or plain strings.

Tests:
- Add unit tests covering multiline filter and dataset help text normalization, including YAML-style multiline health_theme help text blocks.